### PR TITLE
Pass color token comments through to SwiftUI as Color docstrings

### DIFF
--- a/figma_plugin/src/core/models/color.ts
+++ b/figma_plugin/src/core/models/color.ts
@@ -1,5 +1,6 @@
 export interface Color {
   readonly name: string
+  readonly description: string
   readonly red: number
   readonly green: number
   readonly blue: number

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -18,6 +18,7 @@ export interface PluginAPIProtocol {
 
 export interface PaintStyleProtocol {
    name: string
+   description: string
    paints: ReadonlyArray<PaintProtocol>
 }
 

--- a/figma_plugin/src/core/origins/figma/infer_colors.ts
+++ b/figma_plugin/src/core/origins/figma/infer_colors.ts
@@ -23,6 +23,7 @@ export function paintStyleToColor(paintStyle: PaintStyleProtocol): Color | null 
   if (paint) {
     return {
       name: camelCase(paintStyle.name),
+      description: paintStyle.description,
       red: paint.color.r,
       green: paint.color.g,
       blue: paint.color.b,

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -1,8 +1,12 @@
 import { Color } from 'src/core/models/color.ts'
 
 // Given a color model, return an equivalent SwiftUI color definition.
-export function emitColor(color: Color): string {
-  return `public static let ${color.name} = Color(red: ${color.red}, green: ${color.green}, blue: ${color.blue}, opacity: ${color.opacity})`
+export function emitColor(color: Color, indentLevel: number = 0): string {
+  const prefix = ' '.repeat(indentLevel)
+  return [
+    `${prefix}/// ${color.description}`,
+    `${prefix}public static let ${color.name} = Color(red: ${color.red}, green: ${color.green}, blue: ${color.blue}, opacity: ${color.opacity})`
+  ].join("\n")
 }
 
 // Given a list of colors, return an equivalent SwiftUI file defining all colors.
@@ -17,8 +21,9 @@ public extension Color {
     /// At any call site that requires a color, type \`Color.DesignSystem.<esc>\`
     struct DesignSystem {
 `
+  const indentLevel = 8
   for (const color of colors) {
-    swift_content += `        ${emitColor(color)}\n`
+    swift_content += `${emitColor(color, indentLevel)}\n`
   }
 
   swift_content += "    }\n}\n"

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -1,7 +1,7 @@
 import { Color } from 'src/core/models/color.ts'
 
 // Given a color model, return an equivalent SwiftUI color definition.
-export function emitColor(color: Color, indentLevel: number = 0): string {
+export function emitColor(color: Color, indentLevel = 0): string {
   const prefix = ' '.repeat(indentLevel)
   return [
     `${prefix}/// ${color.description}`,

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -1,0 +1,23 @@
+import { PaintProtocol } from '../src/core/origins/figma/api_bridge.ts'
+import { PaintStyleProtocol } from '../src/core/origins/figma/api_bridge.ts'
+import { SolidPaintProtocol } from '../src/core/origins/figma/api_bridge.ts'
+
+
+interface FactoryPaintStyleProtocol {
+  name?: string
+  description?: string
+  paints?: ReadonlyArray<PaintProtocol>
+}
+
+export function makePaintStyle({ name, description, paints }: FactoryPaintStyleProtocol = {})
+: PaintStyleProtocol {
+  return {
+    name: name || "default color",
+    description: description || "default description",
+    paints: paints || [makePaint()]
+  }
+}
+
+function makePaint(): SolidPaintProtocol {
+  return {type: 'SOLID', color: {r: 1, g: 1, b: 1}, opacity: 0.5}
+}


### PR DESCRIPTION
The description used in the color style defined in Figma is passed into the
code generator for SwiftUI as a doctring:

<img width="688" alt="Screenshot 2023-06-02 at 18 02 48" src="https://github.com/lzell/dscompiler/assets/35940/5302d429-3d6f-432f-aeed-c6f75417d5e1">
