### PR TITLE
Add linear gradient support

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -55,6 +55,24 @@ Run tests on filesystem changes to `figma_plugin/src` and `figma_plugin/test`:
     :: type 'a' when jest prompt appears
 
 
+### How to debug tests
+
+1. Open devtools:
+  - Open Chrome
+  - Punch `about:inspect` into the address bar
+  - Tap on 'Open dedicated DevTools for Node'
+
+2. Add a `debugger` statement to the source
+
+3. Run `jest` with the following:
+
+    node --inspect-brk node_modules/.bin/jest --runInBand
+
+  To test a single file, use:
+
+    node --inspect-brk node_modules/.bin/jest --runInBand <filename>
+
+
 ### How to run the linter
 
 Run linter:

--- a/figma_plugin/jest.config.js
+++ b/figma_plugin/jest.config.js
@@ -6,6 +6,9 @@ module.exports = {
     // There are no tests in the `src` tree.
     "./src",
   ],
+  "modulePaths": [
+    "<rootDir>",
+  ],
   "testMatch": [
     "**/?(*.)+(spec|test).+(ts|tsx|js)"
   ],

--- a/figma_plugin/package-lock.json
+++ b/figma_plugin/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dscompiler",
       "version": "1.0.0",
       "dependencies": {
+        "@figma-plugin/helpers": "^0.15.2",
         "file-saver": "^2.0.5",
         "liquidjs": "^10.8.2",
         "lodash": "^4.17.21"
@@ -1075,6 +1076,20 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@figma-plugin/helpers": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@figma-plugin/helpers/-/helpers-0.15.2.tgz",
+      "integrity": "sha512-ggFxoefZKc0D/HJXFHqliLWCLQG3QTbByHqgiSpTK0D76qTDv2fpcF9bytjSMVnc4flD7Rq17tLNP/WmaJt3dA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "matrix-inverse": "^1.0.1"
+      }
+    },
+    "node_modules/@figma-plugin/helpers/node_modules/matrix-inverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/matrix-inverse/-/matrix-inverse-1.0.1.tgz",
+      "integrity": "sha512-ubaJ6vEJfpsRpOLYLJN3bCW3VbO2t0OtZIfausKiizsPNCvCXsWsLMR8jm4zmi8bSnodp3ht25iqdpSe0wIbxg=="
     },
     "node_modules/@figma/plugin-typings": {
       "version": "1.65.0",

--- a/figma_plugin/package.json
+++ b/figma_plugin/package.json
@@ -9,7 +9,7 @@
     "bundle_ui": "./node_modules/.bin/esbuild src/ui.ts --bundle --target=es6 --outfile=dist/ui.js && node scripts/buildui.mjs",
     "linter": "npx eslint .",
     "linter_fixer": "npx eslint --fix .",
-    "repl": "npx ts-node -r tsconfig-paths/register",
+    "repl": "npx ts-node -r tsconfig-paths/register -O '{\"noUnusedLocals\": false}'",
     "test": "jest",
     "typecheck": "tsc --project tsconfig.json",
     "watch": "node scripts/watch.mjs",

--- a/figma_plugin/package.json
+++ b/figma_plugin/package.json
@@ -5,8 +5,8 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "npm run bundle_main && npm run bundle_ui",
-    "bundle_main": "./node_modules/.bin/esbuild src/main.ts --bundle --outfile=dist/main.js",
-    "bundle_ui": "./node_modules/.bin/esbuild src/ui.ts --bundle --outfile=dist/ui.js && node scripts/buildui.mjs",
+    "bundle_main": "./node_modules/.bin/esbuild src/main.ts --bundle --target=es6 --outfile=dist/main.js",
+    "bundle_ui": "./node_modules/.bin/esbuild src/ui.ts --bundle --target=es6 --outfile=dist/ui.js && node scripts/buildui.mjs",
     "linter": "npx eslint .",
     "linter_fixer": "npx eslint --fix .",
     "repl": "npx ts-node -r tsconfig-paths/register",

--- a/figma_plugin/package.json
+++ b/figma_plugin/package.json
@@ -34,6 +34,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
+    "@figma-plugin/helpers": "^0.15.2",
     "file-saver": "^2.0.5",
     "liquidjs": "^10.8.2",
     "lodash": "^4.17.21"

--- a/figma_plugin/scripts/watch.mjs
+++ b/figma_plugin/scripts/watch.mjs
@@ -36,10 +36,12 @@ function bundleAndTypecheck() {
 }
 
 // Watch for file system changes
-fs.watch("src", {recursive: true}, (eventType, filename) => {
-  if (fileExtensionsToWatch.includes(path.extname(filename))) {
-    fileDidChangeFn(filename)
-  }
+["src", "test"].forEach(dir => {
+  fs.watch(dir, {recursive: true}, (eventType, filename) => {
+    if (fileExtensionsToWatch.includes(path.extname(filename))) {
+      fileDidChangeFn(filename)
+    }
+  });
 });
 
 // Build everything one time when I run 'npm run watch'.

--- a/figma_plugin/src/core/models/color.ts
+++ b/figma_plugin/src/core/models/color.ts
@@ -1,8 +1,11 @@
-export interface Color {
-  readonly name: string
-  readonly description: string
+export type Color = {
   readonly red: number
   readonly green: number
   readonly blue: number
-  readonly opacity: number
+  readonly opacity?: number
+}
+
+export type NamedColor = Color & {
+  readonly name: string
+  readonly description: string
 }

--- a/figma_plugin/src/core/models/gradient.ts
+++ b/figma_plugin/src/core/models/gradient.ts
@@ -1,0 +1,18 @@
+import { Color } from 'src/core/models/color.ts'
+import { Point } from 'src/core/models/point.ts'
+
+export type GradientStop = {
+  color: Color
+  location: number
+}
+
+export type LinearGradient = {
+  stops: ReadonlyArray<GradientStop>
+  startPoint: Point
+  endPoint: Point
+}
+
+export type NamedGradient = LinearGradient & {
+  readonly name: string
+  readonly description: string
+}

--- a/figma_plugin/src/core/models/point.ts
+++ b/figma_plugin/src/core/models/point.ts
@@ -1,0 +1,4 @@
+export type Point = {
+  x: number
+  y: number
+}

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -5,13 +5,17 @@
 //   node_modules/@figma/plugin-typings/plugin-api.d.ts
 //
 // We duplicate parts of the API definition for dependency isolation.
-// Source code under `src/core` can run outside of Figma's plugin environment.
+// Source code under `src/core` can run outside of Figma's plugin environment (e.g. in tests).
 // It also serves as a reference to quickly see which parts of the plugin API we use.
 //
-// Type names are almost have `Protocol` appended to them to distinguish them from
+// Type names have `I` prepended to them to distinguish them from
 // from Figma's plugin types. The idea is that call sites can use a type
-// passed from Figma, or from one of our own creation that conforms to <FigmaType>Protocol
+// passed from Figma, or from one of our own creation that conforms to I<FigmaType>
 // that we craft ourselves, which is helpful for testing.
+//
+// If we did not declare a subset of the API, it would be unwieldy to craft tests,
+// as we'd have to satisfy the full type contract defined by figma in our factories
+// (which would include many members and methods that we do not use).
 export interface IPluginAPI {
   getLocalPaintStyles(): IPaintStyle[]
 }
@@ -22,15 +26,19 @@ export interface IPaintStyle {
    paints: ReadonlyArray<IPaint>
 }
 
-export interface RGBProtocol {
+export interface IRGB {
   readonly r: number
   readonly g: number
   readonly b: number
 }
 
+export interface IRGBA extends IRGB {
+  readonly a: number
+}
+
 export interface ISolidPaint {
   readonly type: 'SOLID'
-  readonly color: RGBProtocol
+  readonly color: IRGB
   readonly opacity?: number
 }
 

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -50,8 +50,18 @@ export interface IImagePaint {
   readonly type: 'IMAGE'
 }
 
+export declare type ITransform = [[number, number, number], [number, number, number]]
+
+export interface IColorStop {
+  readonly position: number
+  readonly color: IRGBA
+}
+
 export interface IGradientPaint {
   readonly type: 'GRADIENT_LINEAR' | 'GRADIENT_RADIAL' | 'GRADIENT_ANGULAR' | 'GRADIENT_DIAMOND'
+  readonly gradientTransform: ITransform
+  readonly gradientStops: ReadonlyArray<IColorStop>
+  readonly opacity?: number
 }
 
 export declare type IPaint = ISolidPaint | IGradientPaint | IImagePaint | IVideoPaint

--- a/figma_plugin/src/core/origins/figma/infer_colors.ts
+++ b/figma_plugin/src/core/origins/figma/infer_colors.ts
@@ -15,7 +15,6 @@ function onlySolidPaintStyles(paintStyle: IPaintStyle): boolean {
   return hasPaints && paintStyle.paints[0].type === 'SOLID'
 }
 
-
 // Given Figma's 'plugin' global, returns an array of NamedColor models.
 // Every solid paint saved as a "local style" in Figma is mapped to a NamedColor.
 export function inferColors(figma: IPluginAPI): ReadonlyArray<NamedColor> {
@@ -23,7 +22,6 @@ export function inferColors(figma: IPluginAPI): ReadonlyArray<NamedColor> {
                  .filter(onlySolidPaintStyles)
                  .map(paintStyleToColor))
 }
-
 
 // Given a paint style consisting of a solid paint, return a NamedColor model.
 // The name of the paint style is camelCased to form the NamedColor model name.

--- a/figma_plugin/src/core/origins/figma/infer_colors.ts
+++ b/figma_plugin/src/core/origins/figma/infer_colors.ts
@@ -1,34 +1,46 @@
 import { camelCase } from 'lodash'
 import { compact } from 'lodash'
-import { IPaint } from 'src/core/origins/figma/api_bridge.ts'
+
+// API bridge types
 import { IPaintStyle } from 'src/core/origins/figma/api_bridge.ts'
 import { IPluginAPI } from 'src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from 'src/core/origins/figma/api_bridge.ts'
-import { Color } from 'src/core/models/color.ts'
 
-// Given Figma's 'plugin' global, returns an array of Color models.
-// Colors are mapped from Figma's PaintStyle type to our Color type.
-export function inferColors(figma: IPluginAPI): ReadonlyArray<Color> {
-  return compact(figma.getLocalPaintStyles().map(paintStyleToColor))
+// DSCompiler
+import { Color } from 'src/core/models/color.ts'
+import { NamedColor } from 'src/core/models/color.ts'
+
+function onlySolidPaintStyles(paintStyle: IPaintStyle): boolean {
+  const hasPaints = paintStyle.paints.length >= 1
+  return hasPaints && paintStyle.paints[0].type === 'SOLID'
 }
 
-// Given a paint style, return a Color model if we can.
-// The only supported PaintStyle type right now is `SolidPaint`.
-// All other paint styles are ignored.
-// The name of the paint style is camelCased to form the Color model name.
-export function paintStyleToColor(paintStyle: IPaintStyle): Color | null {
-  console.assert(paintStyle.paints.length > 0, "Expected paint styles to have at least one paint")
-  const isSolid = (paint: IPaint): paint is ISolidPaint => paint.type === "SOLID"
-  const paint = paintStyle.paints.find(isSolid)
-  if (paint) {
-    return {
-      name: camelCase(paintStyle.name),
-      description: paintStyle.description,
-      red: paint.color.r,
-      green: paint.color.g,
-      blue: paint.color.b,
-      opacity: paint.opacity ?? 1
-    }
+
+// Given Figma's 'plugin' global, returns an array of NamedColor models.
+// Every solid paint saved as a "local style" in Figma is mapped to a NamedColor.
+export function inferColors(figma: IPluginAPI): ReadonlyArray<NamedColor> {
+  return compact(figma.getLocalPaintStyles()
+                 .filter(onlySolidPaintStyles)
+                 .map(paintStyleToColor))
+}
+
+
+// Given a paint style consisting of a solid paint, return a NamedColor model.
+// The name of the paint style is camelCased to form the NamedColor model name.
+export function paintStyleToColor(paintStyle: IPaintStyle): NamedColor {
+  console.assert(paintStyle.paints.length == 1, "Expected paint styles to have exactly one paint")
+  console.assert(paintStyle.paints[0].type == 'SOLID', "Expected paint style to have a solid paint")
+  const paint: ISolidPaint = paintStyle.paints[0] as ISolidPaint
+  const color = solidPaintToColor(paint)
+  const named = {name: camelCase(paintStyle.name), description: paintStyle.description}
+  return { ...named, ...color }
+}
+
+function solidPaintToColor(solidPaint: ISolidPaint): Color {
+  return {
+    red: solidPaint.color.r,
+    green: solidPaint.color.g,
+    blue: solidPaint.color.b,
+    opacity: solidPaint.opacity ?? 1
   }
-  return null
 }

--- a/figma_plugin/src/core/origins/figma/infer_gradients.ts
+++ b/figma_plugin/src/core/origins/figma/infer_gradients.ts
@@ -1,0 +1,63 @@
+import { camelCase } from 'lodash'
+import { compact } from 'lodash'
+import { extractLinearGradientParamsFromTransform } from "@figma-plugin/helpers";
+
+// API bridge types
+import { IGradientPaint } from 'src/core/origins/figma/api_bridge.ts'
+import { IPaintStyle } from 'src/core/origins/figma/api_bridge.ts'
+import { IPluginAPI } from 'src/core/origins/figma/api_bridge.ts'
+import { ITransform } from 'src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { GradientStop } from 'src/core/models/gradient.ts'
+import { LinearGradient } from 'src/core/models/gradient.ts'
+import { NamedGradient } from 'src/core/models/gradient.ts'
+import { Point } from 'src/core/models/point.ts'
+import { logToUser } from 'src/core/utils/log.ts'
+
+function onlyLinearGradientPaintStyles(paintStyle: IPaintStyle): boolean {
+  const hasPaints = paintStyle.paints.length >= 1
+  return hasPaints && paintStyle.paints[0].type === 'GRADIENT_LINEAR'
+}
+
+// Given Figma's 'plugin' global, returns an array of NamedGradient models.
+// Every linear gradient paint saved as a "local style" in Figma is mapped to a NamedGradient.
+export function inferGradients(figma: IPluginAPI): ReadonlyArray<NamedGradient> {
+  return compact(figma.getLocalPaintStyles()
+                 .filter(onlyLinearGradientPaintStyles)
+                 .map(paintStyleToLinearGradient))
+}
+
+// Given a paint style consisting of a linear gradient, return a NamedGradient model.
+// The name of the paint style is camelCased to form the NamedGradient model name.
+export function paintStyleToLinearGradient(paintStyle: IPaintStyle): NamedGradient {
+  console.assert(paintStyle.paints.length == 1, "Expected paint styles to have exactly one paint")
+  console.assert(paintStyle.paints[0].type == 'GRADIENT_LINEAR', "Expected paint style to have a linear gradient paint")
+  const paint = paintStyle.paints[0] as IGradientPaint
+  if (paint.opacity != 1) {
+    logToUser("DSCompiler expects gradient opacities to be applied to color stops, not the overall gradient")
+  }
+  const gradient = gradientPaintToLinearGradient(paint)
+  const named = {name: camelCase(paintStyle.name), description: paintStyle.description}
+  return { ...named, ...gradient }
+}
+
+function gradientPaintToLinearGradient(gradientPaint: IGradientPaint): LinearGradient {
+
+  const points = transformToModelCoordinates(gradientPaint.gradientTransform)
+  const stops: GradientStop[] = gradientPaint.gradientStops.map(stop => {
+    return {
+      color: { red: stop.color.r, green: stop.color.g, blue: stop.color.b, opacity: stop.color.a },
+      location: stop.position
+    }
+  })
+  return {
+    stops: stops,
+    ...points
+  }
+}
+
+export function transformToModelCoordinates(transform: ITransform): {startPoint: Point, endPoint: Point} {
+  const tmp = extractLinearGradientParamsFromTransform(1, 1, transform)
+  return { startPoint: {x: tmp.start[0], y: tmp.start[1]}, endPoint: {x:tmp.end[0], y: tmp.end[1]} }
+}

--- a/figma_plugin/src/core/origins/figma/infer_gradients.ts
+++ b/figma_plugin/src/core/origins/figma/infer_gradients.ts
@@ -1,6 +1,6 @@
 import { camelCase } from 'lodash'
 import { compact } from 'lodash'
-import { extractLinearGradientParamsFromTransform } from "@figma-plugin/helpers";
+import { extractLinearGradientParamsFromTransform } from "@figma-plugin/helpers"
 
 // API bridge types
 import { IGradientPaint } from 'src/core/origins/figma/api_bridge.ts'

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -1,7 +1,7 @@
-import { Color } from 'src/core/models/color.ts'
+import { NamedColor } from 'src/core/models/color.ts'
 
 // Given a color model, return an equivalent SwiftUI color definition.
-export function emitColor(color: Color, indentLevel = 0): string {
+export function emitColor(color: NamedColor, indentLevel = 0): string {
   const prefix = ' '.repeat(indentLevel)
   return [
     `${prefix}/// ${color.description}`,
@@ -9,8 +9,9 @@ export function emitColor(color: Color, indentLevel = 0): string {
   ].join("\n")
 }
 
+
 // Given a list of colors, return an equivalent SwiftUI file defining all colors.
-export function emitColors(colors: ReadonlyArray<Color>): string {
+export function emitColors(colors: ReadonlyArray<NamedColor>): string {
   let swift_content = `import SwiftUI
 
 public extension Color {
@@ -21,10 +22,12 @@ public extension Color {
     /// At any call site that requires a color, type \`Color.DesignSystem.<esc>\`
     struct DesignSystem {
 `
+
   const indentLevel = 8
   for (const color of colors) {
-    swift_content += `${emitColor(color, indentLevel)}\n`
+    swift_content += `${emitColor(color, indentLevel)}\n\n`
   }
+  swift_content = swift_content.slice(0, -1)
 
   swift_content += "    }\n}\n"
   return swift_content

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -9,7 +9,6 @@ export function emitColor(color: NamedColor, indentLevel = 0): string {
   ].join("\n")
 }
 
-
 // Given a list of colors, return an equivalent SwiftUI file defining all colors.
 export function emitColors(colors: ReadonlyArray<NamedColor>): string {
   let swift_content = `import SwiftUI
@@ -22,7 +21,6 @@ public extension Color {
     /// At any call site that requires a color, type \`Color.DesignSystem.<esc>\`
     struct DesignSystem {
 `
-
   const indentLevel = 8
   for (const color of colors) {
     swift_content += `${emitColor(color, indentLevel)}\n\n`

--- a/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
@@ -2,7 +2,7 @@ import { NamedGradient } from 'src/core/models/gradient.ts'
 
 // Given a gradient model, return an equivalent SwiftUI gradient definition.
 export function emitGradient(gradient: NamedGradient, indentLevel = 0): string {
-  let prefix = ' '.repeat(indentLevel)
+  const prefix = ' '.repeat(indentLevel)
   let swift_content = `${prefix}/// ${gradient.description}\n`
   swift_content += `${prefix}public static let ${gradient.name} = LinearGradient(\n`
   swift_content += `${prefix}    stops: [\n`
@@ -28,7 +28,6 @@ public extension LinearGradient {
     /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<esc>\`
     struct DesignSystem {
 `
-
   const indentLevel = 8
   for (const gradient of gradients) {
     swift_content += `${emitGradient(gradient, indentLevel)}\n\n`

--- a/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
@@ -1,0 +1,40 @@
+import { NamedGradient } from 'src/core/models/gradient.ts'
+
+// Given a gradient model, return an equivalent SwiftUI gradient definition.
+export function emitGradient(gradient: NamedGradient, indentLevel = 0): string {
+  let prefix = ' '.repeat(indentLevel)
+  let swift_content = `${prefix}/// ${gradient.description}\n`
+  swift_content += `${prefix}public static let ${gradient.name} = LinearGradient(\n`
+  swift_content += `${prefix}    stops: [\n`
+  gradient.stops.forEach(stop => {
+    swift_content += `${prefix}        Gradient.Stop(color: Color(red: ${stop.color.red}, green: ${stop.color.green}, blue: ${stop.color.blue}, opacity: ${stop.color.opacity ?? 1}), location: ${stop.location}),\n`
+  })
+  swift_content += `${prefix}    ],\n`
+  swift_content += `${prefix}    startPoint: UnitPoint(x: ${gradient.startPoint.x}, y: ${gradient.startPoint.y}),\n`
+  swift_content += `${prefix}    endPoint: UnitPoint(x: ${gradient.endPoint.x}, y: ${gradient.endPoint.y})\n`
+  swift_content += `${prefix})`
+  return swift_content
+}
+
+// Given a list of gradients, return an equivalent SwiftUI file defining all gradients.
+export function emitGradients(gradients: ReadonlyArray<NamedGradient>): string {
+  let swift_content = `import SwiftUI
+
+public extension LinearGradient {
+    /// Namespace to prevent naming collisions with static accessors on
+    /// SwiftUI's LinearGradient.
+    ///
+    /// Xcode's autocomplete allows for easy discovery of design system linear gradients.
+    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<esc>\`
+    struct DesignSystem {
+`
+
+  const indentLevel = 8
+  for (const gradient of gradients) {
+    swift_content += `${emitGradient(gradient, indentLevel)}\n\n`
+  }
+  swift_content = swift_content.slice(0, -1)
+
+  swift_content += "    }\n}\n"
+  return swift_content
+}

--- a/figma_plugin/src/core/utils/log.ts
+++ b/figma_plugin/src/core/utils/log.ts
@@ -1,0 +1,5 @@
+// This should eventually be sent to the UI.
+// For now, we write to the console.
+export function logToUser(msg: string) {
+  console.log(`DSCompiler warning: ${msg}`)
+}

--- a/figma_plugin/src/main.ts
+++ b/figma_plugin/src/main.ts
@@ -1,31 +1,47 @@
-import { inferColors } from 'src/core/origins/figma/infer_colors.ts'
 import { emitColors } from 'src/core/targets/swiftui/emit_colors.ts'
+import { emitGradients } from 'src/core/targets/swiftui/emit_gradients.ts'
+import { inferColors } from 'src/core/origins/figma/infer_colors.ts'
+import { inferGradients } from 'src/core/origins/figma/infer_gradients.ts'
 
 figma.showUI(__html__)
 
+// Returns SwiftUI colors to the caller (the browser environment)
+function returnSwiftUIColors() {
+  figma.ui.postMessage(
+    {
+      'message': 'return-export-colors-button-action',
+      'argument': {
+        'file_name': 'Color.swift',
+        'file_body': emitColors(inferColors(figma)),
+      }
+    }
+  )
+}
+
+// Returns SwiftUI gradients to the caller (the browser environment)
+function returnSwiftUIGradients() {
+  figma.ui.postMessage(
+    {
+      'message': 'return-export-gradients-button-action',
+      'argument': {
+        'file_name': 'LinearGradient.swift',
+        'file_body': emitGradients(inferGradients(figma)),
+      }
+    }
+  )
+}
+
+const messageCallDictionary: Record<string, () => void> = {
+  'close-button-action': figma.closePlugin,
+  'export-colors-button-action': returnSwiftUIColors,
+  'export-gradients-button-action': returnSwiftUIGradients,
+}
+
 figma.ui.onmessage = msg => {
-  switch (msg.type) {
-    case 'close-button-action': {
-      figma.closePlugin()
-      break
-    }
-    case 'export-button-action': {
-      const colors = inferColors(figma)
-      const swiftColors = emitColors(colors)
-      figma.ui.postMessage(
-        {
-          'message': 'return-export-button-action',
-          'argument': {
-            'file_name': 'Color.swift',
-            'file_body': swiftColors,
-          }
-        }
-      )
-      break
-    }
-    default: {
-      console.assert(false, 'Received a message from the UI that dscompiler does not understand')
-      break
-    }
+  const handler: any = messageCallDictionary[msg.type]
+  if (handler) {
+    handler()
+  } else {
+    console.assert(false, 'Received a message from the UI that dscompiler does not understand')
   }
 }

--- a/figma_plugin/src/ui.html.liquid
+++ b/figma_plugin/src/ui.html.liquid
@@ -1,5 +1,9 @@
 <div>
-  <button id='export-button'>Export to SwiftUI</button>
+  <button id='export-colors-button'>Emit SwiftUI Colors</button>
+</div>
+<br>
+<div>
+  <button id='export-gradients-button'>Emit SwiftUI Gradients</button>
 </div>
 <br>
 <div>

--- a/figma_plugin/src/ui.ts
+++ b/figma_plugin/src/ui.ts
@@ -1,6 +1,5 @@
 import { saveAs } from 'file-saver'
 
-
 // When a user taps a button in the UI, I pass an event to the plugin sandbox
 // of the form '<name>-action'. The plugin sandbox is then responsible for
 // returning a message of form 'return-<name>-action'.
@@ -11,10 +10,10 @@ window.onmessage = async (event) => {
   const pluginMessage = event.data?.pluginMessage
   console.assert(pluginMessage, "Expecting a plugin message")
   switch (pluginMessage['message']) {
-    case 'return-export-button-action':
+    case 'return-export-colors-button-action':
+    case 'return-export-gradients-button-action':
       exportButtonActionDidReturn(pluginMessage['argument'])
       break
-    case 'return-export-text-styles':
     default:
       console.assert(false, 'Received an unsupported message from the plugin: ' + event.data.pluginMessage['message'])
       break
@@ -27,9 +26,9 @@ function exportButtonActionDidReturn(messageArgument: any) {
   const fileBody = messageArgument['file_body']
   console.assert(fileName, 'missing required file_name argument')
   console.assert(fileBody, 'missing required file_body argument')
+  console.info(fileBody)
   saveAs(new Blob([fileBody], {type: "text/plain;charset=utf-8"}), fileName)
 }
-
 
 // Attaches handlers to UI buttons that sends the `action` message to
 // the figma plugin sandbox. The `buttonsAndActions` argument has the following form:
@@ -52,9 +51,9 @@ function attachButtonActions(buttonsAndActions: [string, string][]) {
   }
 }
 
-
 // Attach button actions:
 attachButtonActions([
   ['close-button', 'close-button-action'],
-  ['export-button', 'export-button-action'],
+  ['export-colors-button', 'export-colors-button-action'],
+  ['export-gradients-button', 'export-gradients-button-action'],
 ])

--- a/figma_plugin/test/color.test.ts
+++ b/figma_plugin/test/color.test.ts
@@ -1,13 +1,17 @@
-import { Color } from '../src/core/models/color.ts'
-import { inferColors } from '../src/core/origins/figma/infer_colors.ts'
-import { emitColor } from '../src/core/targets/swiftui/emit_colors.ts'
-import { emitColors } from '../src/core/targets/swiftui/emit_colors.ts'
-import { paintStyleToColor } from '../src/core/origins/figma/infer_colors.ts'
-import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
-import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
+// API bridge types
 import { IImagePaint } from '../src/core/origins/figma/api_bridge.ts'
+import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IVideoPaint } from '../src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { NamedColor } from '../src/core/models/color.ts'
+import { emitColor } from '../src/core/targets/swiftui/emit_colors.ts'
+import { emitColors } from '../src/core/targets/swiftui/emit_colors.ts'
+import { inferColors } from '../src/core/origins/figma/infer_colors.ts'
+import { paintStyleToColor } from '../src/core/origins/figma/infer_colors.ts'
+
+// Specific to testing
 import { makePaintStyle } from './factories.ts'
 
 test("Infering colors from Figma uses the plugin API call getLocalPaintStyles", () => {
@@ -17,17 +21,19 @@ test("Infering colors from Figma uses the plugin API call getLocalPaintStyles", 
   expect(getLocalPaintStyles).toHaveBeenCalled()
 })
 
-test("Paint colors that are not solid are ignored", () => {
-  const gradientPaint: IGradientPaint = {type: 'GRADIENT_LINEAR'}
+test("Image paints and video paints are ignored", () => {
   const imagePaint: IImagePaint = {type: 'IMAGE'}
   const videoPaint: IVideoPaint = {type: 'VIDEO'}
-  const paintStyle = makePaintStyle({paints: [gradientPaint, imagePaint, videoPaint]})
-  expect(paintStyleToColor(paintStyle)).toBe(null)
+
+  const paintStyle = makePaintStyle({paints: [imagePaint, videoPaint]})
+  const getLocalPaintStyles = jest.fn(() => { return [paintStyle] })
+  const figma = { getLocalPaintStyles: getLocalPaintStyles }
+  expect(inferColors(figma)).toEqual([])
 })
 
-test("A solid paint converts to a color model", () => {
+test("A paint style with solid paint converts to a color model", () => {
   const paint: ISolidPaint = {type: 'SOLID', color: {r: 1, g: 1, b: 1}, opacity: 0.5}
-  const color: Color | null = paintStyleToColor(makePaintStyle({paints: [paint]}))
+  const color = paintStyleToColor(makePaintStyle({paints: [paint]}))
   expect(color).toMatchObject({
     red: 1,
     green: 1,
@@ -36,16 +42,16 @@ test("A solid paint converts to a color model", () => {
   })
 })
 
-test("A solid paint without opacity defaults to opacity of 1", () => {
+test("A solid paint without opacity defaults to a color model with opacity 1", () => {
   const paint: ISolidPaint = {type: 'SOLID', color: {r: 0, g: 0, b: 0}}
-  const color: Color | null = paintStyleToColor(makePaintStyle({paints: [paint]}))
-  expect(color?.opacity).toBe(1)
+  const color = paintStyleToColor(makePaintStyle({paints: [paint]}))
+  expect(color.opacity).toBe(1)
 })
 
 test("Only the first solid paint is considered when converting to a color model", () => {
   const paintA: ISolidPaint = {type: 'SOLID', color: {r: 1, g: 0, b: 0}}
   const paintB: ISolidPaint = {type: 'SOLID', color: {r: 1, g: 1, b: 1}}
-  const color: Color | null = paintStyleToColor(makePaintStyle({paints: [paintA, paintB]}))
+  const color = paintStyleToColor(makePaintStyle({paints: [paintA, paintB]}))
   expect(color).toMatchObject({
     red: 1,
     green: 0,
@@ -55,24 +61,24 @@ test("Only the first solid paint is considered when converting to a color model"
 
 test("A paint style name with spaces in figma is converted to camelcase for the color model", () => {
   const color = paintStyleToColor(makePaintStyle({name: 'primary color'}))
-  expect(color?.name).toBe('primaryColor')
+  expect(color.name).toBe('primaryColor')
 })
 
 test("A paint style description is passed through to color model", () => {
   const color = paintStyleToColor(makePaintStyle({description: 'this is a description'}))
-  expect(color?.description).toBe('this is a description')
+  expect(color.description).toBe('this is a description')
 })
 
-test("A color model has a swiftUI equivalent", () => {
-  const color: Color = { red: 0, green: 1, blue: 0, opacity: 1, name: 'myColor', description: 'My Docstring'}
+test("A named color model has a swiftUI equivalent", () => {
+  const color: NamedColor = { red: 0, green: 1, blue: 0, opacity: 1, name: 'myColor', description: 'My Docstring'}
   expect(emitColor(color)).toBe(
 `/// My Docstring
 public static let myColor = Color(red: 0, green: 1, blue: 0, opacity: 1)`)
 })
 
 test("Multiple color models have a swiftUI file equivalent", () => {
-  const colorA: Color = { red: 0.5, green: 0.5, blue: 0.5, opacity: 0.5, name: 'primaryColor', description: 'Docstring A'}
-  const colorB: Color = { red: 1, green: 1, blue: 1, opacity: 1, name: 'secondaryColor', description: 'Docstring B'}
+  const colorA: NamedColor = { red: 0.5, green: 0.5, blue: 0.5, opacity: 0.5, name: 'primaryColor', description: 'Docstring A'}
+  const colorB: NamedColor = { red: 1, green: 1, blue: 1, opacity: 1, name: 'secondaryColor', description: 'Docstring B'}
   expect(emitColors([colorA, colorB])).toBe(
 `import SwiftUI
 
@@ -85,6 +91,7 @@ public extension Color {
     struct DesignSystem {
         /// Docstring A
         public static let primaryColor = Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.5)
+
         /// Docstring B
         public static let secondaryColor = Color(red: 1, green: 1, blue: 1, opacity: 1)
     }

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -1,12 +1,22 @@
+import { IColorStop } from '../src/core/origins/figma/api_bridge.ts'
+import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from '../src/core/origins/figma/api_bridge.ts'
+import { ITransform } from '../src/core/origins/figma/api_bridge.ts'
 
 
 interface _IPaintStyle {
   name?: string
   description?: string
   paints?: ReadonlyArray<IPaint>
+}
+
+interface _IGradientPaint {
+  type?: 'GRADIENT_LINEAR' | 'GRADIENT_RADIAL' | 'GRADIENT_ANGULAR' | 'GRADIENT_DIAMOND'
+  gradientTransform?: ITransform
+  gradientStops?: ReadonlyArray<IColorStop>
+  opacity?: number
 }
 
 export function makePaintStyle({ name, description, paints }: _IPaintStyle = {})
@@ -20,4 +30,19 @@ export function makePaintStyle({ name, description, paints }: _IPaintStyle = {})
 
 function makePaint(): ISolidPaint {
   return {type: 'SOLID', color: {r: 1, g: 1, b: 1}, opacity: 0.5}
+}
+
+export function makeGradientPaint({ type, gradientTransform, gradientStops, opacity }: _IGradientPaint = {})
+: IGradientPaint {
+  return {
+    type: type || 'GRADIENT_LINEAR',
+    opacity: opacity || 1,
+    gradientStops: gradientStops || makeGradientStops(),
+    gradientTransform: gradientTransform || [[0,1,0], [-1,0,1]]}
+}
+
+function makeGradientStops(): ReadonlyArray<IColorStop> {
+  const colorA = {r: 1, g: 0, b: 0, a: 1}
+  const colorB = {r: 1, g: 1, b: 1, a: 0}
+  return [{color: colorA, position: 0}, {color: colorB, position: 1}]
 }

--- a/figma_plugin/test/gradient.test.ts
+++ b/figma_plugin/test/gradient.test.ts
@@ -1,0 +1,233 @@
+// API bridge types
+import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
+import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
+import { ITransform } from '../src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { NamedGradient } from '../src/core/models/gradient.ts'
+import { Point } from '../src/core/models/point.ts'
+import { emitGradient } from '../src/core/targets/swiftui/emit_gradients.ts'
+import { emitGradients } from '../src/core/targets/swiftui/emit_gradients.ts'
+import { inferGradients } from '../src/core/origins/figma/infer_gradients.ts'
+import { paintStyleToLinearGradient } from '../src/core/origins/figma/infer_gradients.ts'
+import { transformToModelCoordinates } from '../src/core/origins/figma/infer_gradients.ts'
+import { logToUser } from '../src/core/utils/log.ts'
+
+// Specific to testing
+import { makePaintStyle } from './factories.ts'
+import { makeGradientPaint } from './factories.ts'
+
+// Don't actually log to the user.
+// Instead, inspect a mock and ensure the right message is being sent.
+jest.mock('../src/core/utils/log.ts', () => {
+  return { logToUser: jest.fn() }
+})
+afterEach(() => { jest.restoreAllMocks() })
+
+test("Infering gradients from Figma uses the plugin API call getLocalPaintStyles", () => {
+  const getLocalPaintStyles = jest.fn(() => { return Array<IPaintStyle>() })
+  const figma = { getLocalPaintStyles: getLocalPaintStyles }
+  inferGradients(figma)
+  expect(getLocalPaintStyles).toHaveBeenCalled()
+})
+
+test("A paint style with linear paint converts to a linear gradient model", () => {
+  const paint: IGradientPaint = {
+    type: 'GRADIENT_LINEAR',
+    gradientTransform: [[0.5, 0.5, 0], [-0.5, 0.5, 0.5]],
+    gradientStops: [
+      {
+        position: 0,
+        color: {r: 0, g: 0, b:0, a:1}
+      },
+      {
+        position: 1,
+        color: {r: 1, g: 0, b:0, a:1}
+      }
+    ],
+    opacity: 1
+  }
+  const gradient = paintStyleToLinearGradient(makePaintStyle({paints: [paint]}))
+  expect(gradient).toMatchObject({
+    stops: [
+      {location: 0, color: {red: 0, green: 0, blue: 0, opacity: 1}},
+      {location: 1, color: {red: 1, green: 0, blue: 0, opacity: 1}},
+    ],
+    startPoint: {x: 0, y: 0},
+    endPoint: {x: 1, y: 1}
+  })
+})
+
+// In Figma, opacities can be applied to both the color stops, and to the overall gradient.
+// In SwiftUI, opacities are only on the color stops.
+// We do not currently compose the Figma color stop opacities and overal opacities to form derived color stop opacities.
+// Instead, we alert the user that opacities on the overall gradient are not supported.
+test("A gradient paint with an opacity set to other than 1 alerts the user", () => {
+  const paint = makeGradientPaint({opacity: 0.5})
+  paintStyleToLinearGradient(makePaintStyle({paints: [paint]}))
+  expect(logToUser).toBeCalledWith('DSCompiler expects gradient opacities to be applied to color stops, not the overall gradient')
+})
+
+test("Only the first gradient paint is considered when converting to a gradient model", () => {
+  const paintA = makeGradientPaint({gradientStops: [
+    {color: {r: 1, g: 0, b: 0, a: 0}, position: 0},
+    {color: {r: 1, g: 0, b: 0, a: 1}, position: 1},
+  ]})
+  const paintB = makeGradientPaint({gradientStops: [
+    {color: {r: 0, g: 0, b: 1, a: 0}, position: 0},
+    {color: {r: 0, g: 0, b: 1, a: 1}, position: 1},
+  ]})
+  const gradient = paintStyleToLinearGradient(makePaintStyle({paints: [paintA, paintB]}))
+  expect(gradient).toMatchObject({
+    stops: [
+      {location: 0, color: {red: 1, green: 0, blue: 0, opacity: 0}},
+      {location: 1, color: {red: 1, green: 0, blue: 0, opacity: 1}},
+    ]
+  })
+})
+
+test("A paint style name with spaces in figma is converted to camelcase for the gradient model", () => {
+  const paintStyle = makePaintStyle({
+    name: 'my gradient',
+    paints: [makeGradientPaint()]
+  })
+  const gradient = paintStyleToLinearGradient(paintStyle)
+  expect(gradient.name).toBe('myGradient')
+})
+
+test("A paint style description is passed through to the gradient model", () => {
+  const paintStyle = makePaintStyle({
+    description: 'this is a description',
+    paints: [makeGradientPaint()]
+  })
+  const gradient = paintStyleToLinearGradient(paintStyle)
+  expect(gradient.description).toBe('this is a description')
+})
+
+test("A named gradient model has a swiftUI equivalent", () => {
+  const gradient: NamedGradient = {
+    name: 'myGradient',
+    description: 'My Docstring',
+    stops: [
+      {location: 0, color: {red: 1, green: 0, blue: 0, opacity: 0}},
+      {location: 1, color: {red: 1, green: 0, blue: 0, opacity: 1}},
+    ],
+    startPoint: {x: 0, y: 0},
+    endPoint: {x: 1, y: 1}
+  }
+  expect(emitGradient(gradient)).toBe(
+`/// My Docstring
+public static let myGradient = LinearGradient(
+    stops: [
+        Gradient.Stop(color: Color(red: 1, green: 0, blue: 0, opacity: 0), location: 0),
+        Gradient.Stop(color: Color(red: 1, green: 0, blue: 0, opacity: 1), location: 1),
+    ],
+    startPoint: UnitPoint(x: 0, y: 0),
+    endPoint: UnitPoint(x: 1, y: 1)
+)`)
+})
+
+test("Multiple gradient models have a swiftUI file equivalent", () => {
+  const gradientA: NamedGradient = {
+    name: 'gradientA',
+    description: 'My first docstring',
+    stops: [
+      {location: 0, color: {red: 1, green: 0, blue: 0, opacity: 0}},
+      {location: 1, color: {red: 1, green: 0, blue: 0, opacity: 1}},
+    ],
+    startPoint: {x: 0, y: 0},
+    endPoint: {x: 1, y: 1}
+  }
+  const gradientB: NamedGradient = {
+    name: 'gradientB',
+    description: 'My second docstring',
+    stops: [
+      {location: 0, color: {red: 0, green: 0, blue: 1, opacity: 0}},
+      {location: 1, color: {red: 0, green: 0, blue: 1, opacity: 1}},
+    ],
+    startPoint: {x: 0.5, y: 0},
+    endPoint: {x: 0.5, y: 1}
+  }
+  expect(emitGradients([gradientA, gradientB])).toBe(
+`import SwiftUI
+
+public extension LinearGradient {
+    /// Namespace to prevent naming collisions with static accessors on
+    /// SwiftUI's LinearGradient.
+    ///
+    /// Xcode's autocomplete allows for easy discovery of design system linear gradients.
+    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<esc>\`
+    struct DesignSystem {
+        /// My first docstring
+        public static let gradientA = LinearGradient(
+            stops: [
+                Gradient.Stop(color: Color(red: 1, green: 0, blue: 0, opacity: 0), location: 0),
+                Gradient.Stop(color: Color(red: 1, green: 0, blue: 0, opacity: 1), location: 1),
+            ],
+            startPoint: UnitPoint(x: 0, y: 0),
+            endPoint: UnitPoint(x: 1, y: 1)
+        )
+
+        /// My second docstring
+        public static let gradientB = LinearGradient(
+            stops: [
+                Gradient.Stop(color: Color(red: 0, green: 0, blue: 1, opacity: 0), location: 0),
+                Gradient.Stop(color: Color(red: 0, green: 0, blue: 1, opacity: 1), location: 1),
+            ],
+            startPoint: UnitPoint(x: 0.5, y: 0),
+            endPoint: UnitPoint(x: 0.5, y: 1)
+        )
+    }
+}
+`)
+})
+
+test("Figma's gradient transforms are convertible into model coordinates", () => {
+  const expectedMappings: Array<{ transform: ITransform, modelCoordinates: { startPoint: Point, endPoint: Point }}> = [
+    {
+      // Tranform for linear gradient from center top to center bottom
+      transform: [[0, 1, 0], [-1, 0, 1]],
+      modelCoordinates: {startPoint: { x: 0.5, y: 0 }, endPoint: { x: 0.5, y: 1 }}
+    },
+    {
+      // Tranform for linear gradient from top left corner to bottom right corner
+      transform: [[0.5, 0.5, 0], [-0.5, 0.5, 0.5]],
+      modelCoordinates: {startPoint: { x: 0, y: 0 }, endPoint: { x: 1, y: 1 }}
+    },
+    {
+      // Tranform for linear gradient from center left to center right
+      transform: [[1, 0, 0], [0, 1, 0]],
+      modelCoordinates: {startPoint: { x: 0, y: 0.5 }, endPoint: { x: 1, y: 0.5 }}
+    },
+    {
+      // Tranform for linear gradient from bottom left corner to top right corner
+      transform: [[0.5, -0.5, 0.5], [0.5, 0.5, 0]],
+      modelCoordinates: {startPoint: { x: 0, y: 1 }, endPoint: { x: 1, y: 0 }}
+    },
+    {
+      // Tranform for linear gradient from center bottom to center top
+      transform: [[0, -1, 1], [1, 0, 0]],
+      modelCoordinates: {startPoint: { x: 0.5, y: 1 }, endPoint: { x: 0.5, y: 0 }}
+    },
+    {
+      // Tranform for linear gradient from bottom right corner to top left corner
+      transform: [[-0.5, -0.5, 1], [0.5, -0.5, 0.5]],
+      modelCoordinates: {startPoint: { x: 1, y: 1 }, endPoint: { x: 0, y: 0 }}
+    },
+    {
+      // Tranform for linear gradient from center right to center left
+      transform: [[-1, 0, 1], [0, -1, 1]],
+      modelCoordinates: {startPoint: { x: 1, y: 0.5 }, endPoint: { x: 0, y: 0.5 }}
+    },
+    {
+      // Tranform for linear gradient from top right corner to bottom left corner
+      transform: [[-0.5, 0.5, 0.5], [-0.5, -0.5, 1]],
+      modelCoordinates: {startPoint: { x: 1, y: 0 }, endPoint: { x: 0, y: 1}}
+    },
+  ]
+
+  for (const expectedMapping of expectedMappings) {
+    const modelCoords = transformToModelCoordinates(expectedMapping.transform)
+    expect(modelCoords).toMatchObject(expectedMapping.modelCoordinates)
+  }
+})

--- a/figma_plugin/tsconfig.json
+++ b/figma_plugin/tsconfig.json
@@ -10,8 +10,9 @@
     ],
     "moduleResolution": "nodenext",
     "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true, // Turn this off when using repl
+    "noUnusedLocals": true,
     "skipLibCheck": true, // https://github.com/figma/plugin-typings/issues/96#issuecomment-982461389
     "strict": true,
     "target": "es6",

--- a/figma_plugin/tsconfig.json
+++ b/figma_plugin/tsconfig.json
@@ -8,6 +8,7 @@
       "dom",
       "es6"
     ],
+    "moduleResolution": "nodenext",
     "noEmit": true,
     "noImplicitAny": true,
     "noUnusedLocals": true, // Turn this off when using repl


### PR DESCRIPTION
- Linear gradient paints saved in Figma as local styles are parsed into a NamedGradient model
- NamedGradient models are emittable to SwiftUI
- Run tests with `npm run test`

Gradients defined in Figma:
<img width="664" alt="Screenshot 2023-06-20 at 09 21 03" src="https://github.com/lzell/dscompiler/assets/35940/62052d28-e4b5-445e-846a-ccc0359b050c">

And code generated SwiftUI gradients:
<img width="1006" alt="Screenshot 2023-06-20 at 09 21 11" src="https://github.com/lzell/dscompiler/assets/35940/456e2e42-2037-4543-8b9a-66ac4eb94752">


