### PR TITLE
Add support for drop shadow and blur effects

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -57,21 +57,26 @@ Run tests on filesystem changes to `figma_plugin/src` and `figma_plugin/test`:
 
 ### How to debug tests
 
-1. Open devtools:
-  - Open Chrome
-  - Punch `about:inspect` into the address bar
-  - Tap on 'Open dedicated DevTools for Node'
+Inside the repl:
 
-2. Add a `debugger` statement to the source
+    node inspect node_modules/.bin/jest <filename>
 
-3. Run `jest` with the following:
+Inside devtools:
 
-    node --inspect-brk node_modules/.bin/jest --runInBand
+    1. Open devtools:
+      - Open Chrome
+      - Punch `about:inspect` into the address bar
+      - Tap on 'Open dedicated DevTools for Node'
 
-  To test a single file, use:
+    2. Add a `debugger` statement to the source
 
-    node --inspect-brk node_modules/.bin/jest --runInBand <filename>
+    3. Run `jest` with the following:
 
+        node --inspect-brk node_modules/.bin/jest --runInBand
+
+      To test a single file, use:
+
+        node --inspect-brk node_modules/.bin/jest --runInBand <filename>
 
 ### How to run the linter
 

--- a/figma_plugin/package-lock.json
+++ b/figma_plugin/package-lock.json
@@ -11,7 +11,8 @@
         "@figma-plugin/helpers": "^0.15.2",
         "file-saver": "^2.0.5",
         "liquidjs": "^10.8.2",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "num-words": "^1.2.3"
       },
       "devDependencies": {
         "@figma/plugin-typings": "^1.68.0",
@@ -4422,6 +4423,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/num-words": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/num-words/-/num-words-1.2.3.tgz",
+      "integrity": "sha512-tfKqF8sCX1sb2LjrZyrqNF7SDyDzxcyKtpNlRqqaOTImmqTEclGYEs17FtpbXsuuyJijwOWzuTy+DasYf/FvlA=="
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/figma_plugin/package.json
+++ b/figma_plugin/package.json
@@ -37,6 +37,7 @@
     "@figma-plugin/helpers": "^0.15.2",
     "file-saver": "^2.0.5",
     "liquidjs": "^10.8.2",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "num-words": "^1.2.3"
   }
 }

--- a/figma_plugin/src/core/models/effect.ts
+++ b/figma_plugin/src/core/models/effect.ts
@@ -1,19 +1,20 @@
 import { Color } from 'src/core/models/color.ts'
 
+// A NamedCompositeEffect can be composed of multiple sub-effects. For example,
+// a named shadow effect may be composed of two shadows with different offsets and colors.
 export type NamedCompositeEffect = {
   readonly name: string
   readonly description: string
   readonly effects: ReadonlyArray<DSEffect>
 }
 
-// Prefix with DS to avoid collision with Figma's Effect type
+// Prefix with DS to avoid confusion with Figma's Effect type
 export type DSEffect = Shadow | Blur
 
 export type Shadow = {
   color: Color
   radius: number
   offset: { x: number, y: number }
-  spread: number | null
 }
 
 export type Blur = {

--- a/figma_plugin/src/core/models/effect.ts
+++ b/figma_plugin/src/core/models/effect.ts
@@ -1,0 +1,20 @@
+import { Color } from 'src/core/models/color.ts'
+
+export type NamedCompositeEffect = {
+  readonly name: string
+  readonly description: string
+  readonly effects: ReadonlyArray<DSEffect>
+}
+
+// Prefix with DS to avoid collision with Figma's Effect type
+export type DSEffect = Shadow | Blur
+
+export type Shadow = {
+  color: Color
+  radius: number
+  offset: { x: number, y: number }
+}
+
+export type Blur = {
+  radius: number
+}

--- a/figma_plugin/src/core/models/effect.ts
+++ b/figma_plugin/src/core/models/effect.ts
@@ -13,6 +13,7 @@ export type Shadow = {
   color: Color
   radius: number
   offset: { x: number, y: number }
+  spread: number | null
 }
 
 export type Blur = {

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -77,7 +77,7 @@ export interface IEffectStyle {
 
 export declare type IEffect = IDropShadowEffect | IInnerShadowEffect | IBlurEffect
 
-interface IDropShadowEffect {
+export interface IDropShadowEffect {
   readonly type: 'DROP_SHADOW'
   readonly color: IRGBA
   readonly offset: {x: number, y: number}
@@ -85,11 +85,11 @@ interface IDropShadowEffect {
   readonly spread?: number
 }
 
-interface IInnerShadowEffect {
+export interface IInnerShadowEffect {
   readonly type: 'INNER_SHADOW'
 }
 
-interface IBlurEffect {
+export interface IBlurEffect {
   readonly type: 'LAYER_BLUR' | 'BACKGROUND_BLUR'
   readonly radius: number
 }

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -4,9 +4,11 @@
 //   node_modules/@figma/plugin-typings/index.d.ts
 //   node_modules/@figma/plugin-typings/plugin-api.d.ts
 //
-// We duplicate parts of the API definition for dependency isolation.
-// Source code under `src/core` can run outside of Figma's plugin environment (e.g. in tests).
-// It also serves as a reference to quickly see which parts of the plugin API we use.
+// We duplicate parts of the API definition to:
+//   1. Isolate dependencies. Source code under `src/core` can run outside of Figma's plugin environment (e.g. in tests).
+//   2. Serve as a reference to quickly see which parts of the plugin API we use.
+//   3. Serve as a static check to ensure the figma API doesn't change out from under us.
+//      If this were to happen, typechecking `/test` would work fine, but typechecking `/src` would fail.
 //
 // Type names have `I` prepended to them to distinguish them from
 // from Figma's plugin types. The idea is that call sites can use a type
@@ -18,6 +20,7 @@
 // (which would include many members and methods that we do not use).
 export interface IPluginAPI {
   getLocalPaintStyles(): IPaintStyle[]
+  getLocalEffectStyles(): IEffectStyle[]
 }
 
 export interface IPaintStyle {
@@ -65,3 +68,28 @@ export interface IGradientPaint {
 }
 
 export declare type IPaint = ISolidPaint | IGradientPaint | IImagePaint | IVideoPaint
+
+export interface IEffectStyle {
+  name: string
+  description: string
+  effects: ReadonlyArray<IEffect>
+}
+
+export declare type IEffect = IDropShadowEffect | IInnerShadowEffect | IBlurEffect
+
+interface IDropShadowEffect {
+  readonly type: 'DROP_SHADOW'
+  readonly color: IRGBA
+  readonly offset: {x: number, y: number}
+  readonly radius: number
+  readonly spread?: number
+}
+
+interface IInnerShadowEffect {
+  readonly type: 'INNER_SHADOW'
+}
+
+interface IBlurEffect {
+  readonly type: 'LAYER_BLUR' | 'BACKGROUND_BLUR'
+  readonly radius: number
+}

--- a/figma_plugin/src/core/origins/figma/infer_colors.ts
+++ b/figma_plugin/src/core/origins/figma/infer_colors.ts
@@ -1,4 +1,3 @@
-import { camelCase } from 'lodash'
 import { compact } from 'lodash'
 
 // API bridge types
@@ -9,6 +8,7 @@ import { ISolidPaint } from 'src/core/origins/figma/api_bridge.ts'
 // DSCompiler
 import { Color } from 'src/core/models/color.ts'
 import { NamedColor } from 'src/core/models/color.ts'
+import { sanitizeName } from 'src/core/utils/common.ts'
 
 function onlySolidPaintStyles(paintStyle: IPaintStyle): boolean {
   const hasPaints = paintStyle.paints.length >= 1
@@ -30,7 +30,7 @@ export function paintStyleToColor(paintStyle: IPaintStyle): NamedColor {
   console.assert(paintStyle.paints[0].type == 'SOLID', "Expected paint style to have a solid paint")
   const paint: ISolidPaint = paintStyle.paints[0] as ISolidPaint
   const color = solidPaintToColor(paint)
-  const named = {name: camelCase(paintStyle.name), description: paintStyle.description}
+  const named = {name: sanitizeName(paintStyle.name), description: paintStyle.description}
   return { ...named, ...color }
 }
 

--- a/figma_plugin/src/core/origins/figma/infer_effects.ts
+++ b/figma_plugin/src/core/origins/figma/infer_effects.ts
@@ -30,7 +30,7 @@ function effectStyleToCompositeEffect(effectStyle: IEffectStyle): NamedComposite
 
 export function effectToDSEffect(effect: IEffect): DSEffect | null {
   if (effect.type == 'LAYER_BLUR') {
-    return { radius: effect.radius }
+    return { radius: effect.radius / 2 }
   }
 
   if (effect.type == 'DROP_SHADOW') {

--- a/figma_plugin/src/core/origins/figma/infer_effects.ts
+++ b/figma_plugin/src/core/origins/figma/infer_effects.ts
@@ -1,0 +1,48 @@
+import { compact } from 'lodash'
+
+// API bridge types
+import { IEffect } from 'src/core/origins/figma/api_bridge.ts'
+import { IEffectStyle } from 'src/core/origins/figma/api_bridge.ts'
+import { IPluginAPI } from 'src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { DSEffect } from 'src/core/models/effect.ts'
+import { NamedCompositeEffect } from 'src/core/models/effect.ts'
+import { logToUser } from 'src/core/utils/log.ts'
+import { sanitizeName } from 'src/core/utils/common.ts'
+
+export function inferEffects(figma: IPluginAPI): ReadonlyArray<NamedCompositeEffect> {
+  return compact(figma.getLocalEffectStyles()
+                 .map(effectStyleToCompositeEffect))
+}
+
+function effectStyleToCompositeEffect(effectStyle: IEffectStyle): NamedCompositeEffect | null  {
+  const dseffects = compact(effectStyle.effects.map(effectToDSEffect))
+  if (!dseffects.length) {
+    return null
+  }
+  return {
+    name: sanitizeName(effectStyle.name),
+    description: effectStyle.description,
+    effects: dseffects,
+  }
+}
+
+function effectToDSEffect(effect: IEffect): DSEffect | null {
+  if (effect.type == 'LAYER_BLUR') {
+    return { radius: effect.radius }
+  } else if (effect.type == 'DROP_SHADOW') {
+    return {
+      color: {
+        red: effect.color.r,
+        green: effect.color.g,
+        blue: effect.color.b,
+        opacity: effect.color.a,
+      },
+      radius: effect.radius,
+      offset: effect.offset,
+    }
+  }
+  logToUser(`dscompiler does not yet understand effect type ${effect.type}`)
+  return null
+}

--- a/figma_plugin/src/core/origins/figma/infer_effects.ts
+++ b/figma_plugin/src/core/origins/figma/infer_effects.ts
@@ -28,7 +28,7 @@ function effectStyleToCompositeEffect(effectStyle: IEffectStyle): NamedComposite
   }
 }
 
-function effectToDSEffect(effect: IEffect): DSEffect | null {
+export function effectToDSEffect(effect: IEffect): DSEffect | null {
   if (effect.type == 'LAYER_BLUR') {
     return { radius: effect.radius }
   } else if (effect.type == 'DROP_SHADOW') {
@@ -41,8 +41,9 @@ function effectToDSEffect(effect: IEffect): DSEffect | null {
       },
       radius: effect.radius,
       offset: effect.offset,
+      spread: effect.spread ?? null,
     }
   }
-  logToUser(`dscompiler does not yet understand effect type ${effect.type}`)
+  logToUser(`DSCompiler does not yet understand effect type ${effect.type}`)
   return null
 }

--- a/figma_plugin/src/core/origins/figma/infer_effects.ts
+++ b/figma_plugin/src/core/origins/figma/infer_effects.ts
@@ -31,7 +31,14 @@ function effectStyleToCompositeEffect(effectStyle: IEffectStyle): NamedComposite
 export function effectToDSEffect(effect: IEffect): DSEffect | null {
   if (effect.type == 'LAYER_BLUR') {
     return { radius: effect.radius }
-  } else if (effect.type == 'DROP_SHADOW') {
+  }
+
+  if (effect.type == 'DROP_SHADOW') {
+    if (effect.spread != null && effect.spread != 0) {
+      logToUser(`DSCompiler can not yet emit code for drop shadows with spreads. Please see https://github.com/lzell/dscompiler/issues/10`)
+      return null
+    }
+
     return {
       color: {
         red: effect.color.r,
@@ -39,11 +46,11 @@ export function effectToDSEffect(effect: IEffect): DSEffect | null {
         blue: effect.color.b,
         opacity: effect.color.a,
       },
-      radius: effect.radius,
+      radius: effect.radius / 2,  // Apply correction to Figma's radius so that generated SwiftUI is visually equal to the defined effect in Figma
       offset: effect.offset,
-      spread: effect.spread ?? null,
     }
   }
+
   logToUser(`DSCompiler does not yet understand effect type ${effect.type}`)
   return null
 }

--- a/figma_plugin/src/core/origins/figma/infer_gradients.ts
+++ b/figma_plugin/src/core/origins/figma/infer_gradients.ts
@@ -1,4 +1,3 @@
-import { camelCase } from 'lodash'
 import { compact } from 'lodash'
 import { extractLinearGradientParamsFromTransform } from "@figma-plugin/helpers"
 
@@ -14,6 +13,8 @@ import { LinearGradient } from 'src/core/models/gradient.ts'
 import { NamedGradient } from 'src/core/models/gradient.ts'
 import { Point } from 'src/core/models/point.ts'
 import { logToUser } from 'src/core/utils/log.ts'
+import { sanitizeName } from 'src/core/utils/common.ts'
+import { humanifyNumber } from 'src/core/utils/common.ts'
 
 function onlyLinearGradientPaintStyles(paintStyle: IPaintStyle): boolean {
   const hasPaints = paintStyle.paints.length >= 1
@@ -38,7 +39,7 @@ export function paintStyleToLinearGradient(paintStyle: IPaintStyle): NamedGradie
     logToUser("DSCompiler expects gradient opacities to be applied to color stops, not the overall gradient")
   }
   const gradient = gradientPaintToLinearGradient(paint)
-  const named = {name: camelCase(paintStyle.name), description: paintStyle.description}
+  const named = {name: sanitizeName(paintStyle.name), description: paintStyle.description}
   return { ...named, ...gradient }
 }
 
@@ -48,7 +49,7 @@ function gradientPaintToLinearGradient(gradientPaint: IGradientPaint): LinearGra
   const stops: GradientStop[] = gradientPaint.gradientStops.map(stop => {
     return {
       color: { red: stop.color.r, green: stop.color.g, blue: stop.color.b, opacity: stop.color.a },
-      location: stop.position
+      location: humanifyNumber(stop.position)
     }
   })
   return {
@@ -59,5 +60,5 @@ function gradientPaintToLinearGradient(gradientPaint: IGradientPaint): LinearGra
 
 export function transformToModelCoordinates(transform: ITransform): {startPoint: Point, endPoint: Point} {
   const tmp = extractLinearGradientParamsFromTransform(1, 1, transform)
-  return { startPoint: {x: tmp.start[0], y: tmp.start[1]}, endPoint: {x:tmp.end[0], y: tmp.end[1]} }
+  return { startPoint: {x: humanifyNumber(tmp.start[0]), y: humanifyNumber(tmp.start[1])}, endPoint: {x: humanifyNumber(tmp.end[0]), y: humanifyNumber(tmp.end[1])} }
 }

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -1,11 +1,12 @@
 import { NamedColor } from 'src/core/models/color.ts'
+import { escapeSwiftToken } from 'src/core/utils/common.ts'
 
 // Given a color model, return an equivalent SwiftUI color definition.
 export function emitColor(color: NamedColor, indentLevel = 0): string {
   const prefix = ' '.repeat(indentLevel)
   return [
     `${prefix}/// ${color.description}`,
-    `${prefix}public static let ${color.name} = Color(red: ${color.red}, green: ${color.green}, blue: ${color.blue}, opacity: ${color.opacity})`
+    `${prefix}public static let ${escapeSwiftToken(color.name)} = Color(red: ${color.red}, green: ${color.green}, blue: ${color.blue}, opacity: ${color.opacity})`
   ].join("\n")
 }
 

--- a/figma_plugin/src/core/targets/swiftui/emit_colors.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_colors.ts
@@ -19,7 +19,7 @@ public extension Color {
     /// SwiftUI's Color.
     ///
     /// Xcode's autocomplete allows for easy discovery of design system colors.
-    /// At any call site that requires a color, type \`Color.DesignSystem.<esc>\`
+    /// At any call site that requires a color, type \`Color.DesignSystem.<ctrl-space>\`
     struct DesignSystem {
 `
   const indentLevel = 8

--- a/figma_plugin/src/core/targets/swiftui/emit_effects.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_effects.ts
@@ -2,7 +2,7 @@ import { upperFirst } from 'lodash'
 import { DSEffect } from 'src/core/models/effect.ts'
 import { NamedCompositeEffect } from 'src/core/models/effect.ts'
 
-export function emitEffect(effect: DSEffect, indentLevel: number = 0 ): string {
+export function emitEffect(effect: DSEffect, indentLevel = 0 ): string {
   const prefix = ' '.repeat(indentLevel)
   const isShadow = "color" in effect
   if (isShadow) {
@@ -13,7 +13,7 @@ export function emitEffect(effect: DSEffect, indentLevel: number = 0 ): string {
 }
 
 // Given a composite effect model, return an equivalent SwiftUI modifier definition.
-export function emitCompositeEffect(compositeEffect: NamedCompositeEffect, indentLevel: number = 0): string {
+export function emitCompositeEffect(compositeEffect: NamedCompositeEffect, indentLevel = 0): string {
   const prefix = ' '.repeat(indentLevel)
   let swift_content = `${prefix}/// ${compositeEffect.description}\n`
   swift_content += `${prefix}public struct ${upperFirst(compositeEffect.name)}: ViewModifier {\n`
@@ -24,7 +24,7 @@ export function emitCompositeEffect(compositeEffect: NamedCompositeEffect, inden
   }
   swift_content += `${prefix}    }\n`
   swift_content += `${prefix}    public init() {}\n`
-  swift_content += `${prefix}}\n\n`
+  swift_content += `${prefix}}\n`
   return swift_content
 }
 
@@ -34,13 +34,14 @@ export function emitCompositeEffects(compositeEffects: ReadonlyArray<NamedCompos
 
 public struct Effect {
     /// Xcode's autocomplete allows for easy discovery of design system effects.
-    /// At any call site that requires an effect, type \`Effect.DesignSystem.<esc>\`
+    /// At any call site that requires an effect, type \`Effect.DesignSystem.<ctrl-space>\`
     public struct DesignSystem {
 
 `
     for (const compositeEffect of compositeEffects) {
-      swift_content += emitCompositeEffect(compositeEffect, 8)
+      swift_content += emitCompositeEffect(compositeEffect, 8) + "\n"
     }
+    swift_content = swift_content.slice(0, -1)
 
     swift_content += "    }\n}\n\n"
     swift_content += "public extension View {\n"

--- a/figma_plugin/src/core/targets/swiftui/emit_effects.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_effects.ts
@@ -1,0 +1,54 @@
+import { upperFirst } from 'lodash'
+import { DSEffect } from 'src/core/models/effect.ts'
+import { NamedCompositeEffect } from 'src/core/models/effect.ts'
+
+export function emitEffect(effect: DSEffect, indentLevel: number = 0 ): string {
+  const prefix = ' '.repeat(indentLevel)
+  const isShadow = "color" in effect
+  if (isShadow) {
+    return `${prefix}.shadow(color: Color(red:${effect.color.red}, green: ${effect.color.green}, blue: ${effect.color.blue}, opacity: ${effect.color.opacity ?? 1}), radius: ${effect.radius}, x: ${effect.offset.x}, y:${effect.offset.y})\n`
+  } else {
+    return `${prefix}.blur(radius: ${effect.radius})\n`
+  }
+}
+
+// Given a composite effect model, return an equivalent SwiftUI modifier definition.
+export function emitCompositeEffect(compositeEffect: NamedCompositeEffect, indentLevel: number = 0): string {
+  const prefix = ' '.repeat(indentLevel)
+  let swift_content = `${prefix}/// ${compositeEffect.description}\n`
+  swift_content += `${prefix}public struct ${upperFirst(compositeEffect.name)}: ViewModifier {\n`
+  swift_content += `${prefix}    public func body(content: Content) -> some View {\n`
+  swift_content += `${prefix}        return content\n`
+  for (const effect of compositeEffect.effects) {
+    swift_content += emitEffect(effect, indentLevel + 12)
+  }
+  swift_content += `${prefix}    }\n`
+  swift_content += `${prefix}    public init() {}\n`
+  swift_content += `${prefix}}\n\n`
+  return swift_content
+}
+
+export function emitCompositeEffects(compositeEffects: ReadonlyArray<NamedCompositeEffect>): string {
+
+    let swift_content = `import SwiftUI
+
+public struct Effect {
+    /// Xcode's autocomplete allows for easy discovery of design system effects.
+    /// At any call site that requires an effect, type \`Effect.DesignSystem.<esc>\`
+    public struct DesignSystem {
+
+`
+    for (const compositeEffect of compositeEffects) {
+      swift_content += emitCompositeEffect(compositeEffect, 8)
+    }
+
+    swift_content += "    }\n}\n\n"
+    swift_content += "public extension View {\n"
+
+    for (const compositeEffect of compositeEffects) {
+      swift_content += `    func ${compositeEffect.name}() -> some View {modifier(Effect.DesignSystem.${upperFirst(compositeEffect.name)}())}\n`
+    }
+
+    swift_content += "}\n"
+    return swift_content
+}

--- a/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
@@ -1,10 +1,11 @@
 import { NamedGradient } from 'src/core/models/gradient.ts'
+import { escapeSwiftToken } from 'src/core/utils/common.ts'
 
 // Given a gradient model, return an equivalent SwiftUI gradient definition.
 export function emitGradient(gradient: NamedGradient, indentLevel = 0): string {
   const prefix = ' '.repeat(indentLevel)
   let swift_content = `${prefix}/// ${gradient.description}\n`
-  swift_content += `${prefix}public static let ${gradient.name} = LinearGradient(\n`
+  swift_content += `${prefix}public static let ${escapeSwiftToken(gradient.name)} = LinearGradient(\n`
   swift_content += `${prefix}    stops: [\n`
   gradient.stops.forEach(stop => {
     swift_content += `${prefix}        Gradient.Stop(color: Color(red: ${stop.color.red}, green: ${stop.color.green}, blue: ${stop.color.blue}, opacity: ${stop.color.opacity ?? 1}), location: ${stop.location}),\n`

--- a/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_gradients.ts
@@ -26,7 +26,7 @@ public extension LinearGradient {
     /// SwiftUI's LinearGradient.
     ///
     /// Xcode's autocomplete allows for easy discovery of design system linear gradients.
-    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<esc>\`
+    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<ctrl-space>\`
     struct DesignSystem {
 `
   const indentLevel = 8

--- a/figma_plugin/src/core/utils/common.ts
+++ b/figma_plugin/src/core/utils/common.ts
@@ -30,10 +30,7 @@ export function humanifyNumber(value: number): number {
   const integer = Math.trunc(absValue)
   const r = absValue - integer
   if (r < 0.001) {
-    if (integer == -0) {
-      return 0
-    }
-    return sign * integer
+    return integer === 0 ? 0 : sign * integer
   } else if (r > 0.999) {
     return sign * (integer + 1)
   }

--- a/figma_plugin/src/core/utils/common.ts
+++ b/figma_plugin/src/core/utils/common.ts
@@ -1,0 +1,29 @@
+import { camelCase } from 'lodash'
+import numWords from 'num-words'
+
+export function sanitizeName(name: string): string {
+  const hasLeadingDigits = name.match(/^[-+:]?(\d+)/)
+  if (hasLeadingDigits) {
+    const leadingDigits = hasLeadingDigits[1]
+    name = name.replace(leadingDigits, numWords(+leadingDigits))
+  }
+  name = name.replace('-',' minus ')
+  name = name.replace(/[+:\/]/,' ')
+  return camelCase(name)
+}
+
+export function humanifyNumber(value: number): number {
+  const sign = Math.sign(value)
+  const absValue = Math.abs(value)
+  const integer = Math.trunc(absValue)
+  const r = absValue - integer
+  if (r < 0.001) {
+    if (integer == -0) {
+      return 0
+    }
+    return sign * integer
+  } else if (r > 0.999) {
+    return sign * (integer + 1)
+  }
+  return value
+}

--- a/figma_plugin/src/core/utils/common.ts
+++ b/figma_plugin/src/core/utils/common.ts
@@ -1,6 +1,11 @@
 import { camelCase } from 'lodash'
 import numWords from 'num-words'
 
+const SwiftReservedWords = ['associatedtype', 'class', 'deinit', 'enum', 'extension', 'fileprivate', 'func', 'import', 'init', 'inout', 'internal', 'let', 'open', 'operator', 'private', 'protocol', 'public', 'rethrows', 'static', 'struct', 'subscript', 'typealias', 'var',
+  'break', 'case', 'continue', 'default', 'defer', 'do', 'else', 'fallthrough', 'for', 'guard', 'if', 'in', 'repeat', 'return', 'switch', 'where', 'while',
+  'as', 'Any', 'catch', 'false', 'is', 'nil', 'super', 'self', 'Self', 'throw', 'throws', 'true', 'try',
+  'associativity', 'convenience', 'dynamic', 'didSet', 'final', 'get', 'infix', 'indirect', 'lazy', 'left', 'mutating', 'none', 'nonmutating', 'optional', 'override', 'postfix', 'precedence', 'prefix', 'Protocol', 'required', 'right', 'set', 'Type', 'unowned', 'weak', 'willSet']
+
 export function sanitizeName(name: string): string {
   const hasLeadingDigits = name.match(/^[-+:]?(\d+)/)
   if (hasLeadingDigits) {
@@ -10,6 +15,13 @@ export function sanitizeName(name: string): string {
   name = name.replace('-',' minus ')
   name = name.replace(/[+:\/]/,' ')
   return camelCase(name)
+}
+
+export function escapeSwiftToken(name: string): string {
+  if (SwiftReservedWords.includes(name)) {
+    return `\`${name}\``
+  }
+  return name
 }
 
 export function humanifyNumber(value: number): number {

--- a/figma_plugin/src/main.ts
+++ b/figma_plugin/src/main.ts
@@ -1,6 +1,8 @@
 import { emitColors } from 'src/core/targets/swiftui/emit_colors.ts'
+import { emitCompositeEffects } from 'src/core/targets/swiftui/emit_effects.ts'
 import { emitGradients } from 'src/core/targets/swiftui/emit_gradients.ts'
 import { inferColors } from 'src/core/origins/figma/infer_colors.ts'
+import { inferEffects } from 'src/core/origins/figma/infer_effects.ts'
 import { inferGradients } from 'src/core/origins/figma/infer_gradients.ts'
 
 figma.showUI(__html__)
@@ -31,9 +33,23 @@ function returnSwiftUIGradients() {
   )
 }
 
+// Returns SwiftUI effects to the caller (the browser environment)
+function returnSwiftUIEffects() {
+  figma.ui.postMessage(
+    {
+      'message': 'return-export-effects-button-action',
+      'argument': {
+        'file_name': 'Effect.swift',
+        'file_body': emitCompositeEffects(inferEffects(figma)),
+      }
+    }
+  )
+}
+
 const messageCallDictionary: Record<string, () => void> = {
   'close-button-action': figma.closePlugin,
   'export-colors-button-action': returnSwiftUIColors,
+  'export-effects-button-action': returnSwiftUIEffects,
   'export-gradients-button-action': returnSwiftUIGradients,
 }
 

--- a/figma_plugin/src/ui.html.liquid
+++ b/figma_plugin/src/ui.html.liquid
@@ -7,6 +7,10 @@
 </div>
 <br>
 <div>
+  <button id='export-effects-button'>Emit SwiftUI Effects</button>
+</div>
+<br>
+<div>
   <button id='close-button'>Close</button>
 </div>
 

--- a/figma_plugin/src/ui.ts
+++ b/figma_plugin/src/ui.ts
@@ -12,6 +12,7 @@ window.onmessage = async (event) => {
   switch (pluginMessage['message']) {
     case 'return-export-colors-button-action':
     case 'return-export-gradients-button-action':
+    case 'return-export-effects-button-action':
       exportButtonActionDidReturn(pluginMessage['argument'])
       break
     default:
@@ -56,4 +57,5 @@ attachButtonActions([
   ['close-button', 'close-button-action'],
   ['export-colors-button', 'export-colors-button-action'],
   ['export-gradients-button', 'export-gradients-button-action'],
+  ['export-effects-button', 'export-effects-button-action'],
 ])

--- a/figma_plugin/test/color.test.ts
+++ b/figma_plugin/test/color.test.ts
@@ -13,10 +13,11 @@ import { paintStyleToColor } from '../src/core/origins/figma/infer_colors.ts'
 
 // Specific to testing
 import { makePaintStyle } from './factories.ts'
+import { makePluginAPI } from './factories.ts'
 
 test("Infering colors from Figma uses the plugin API call getLocalPaintStyles", () => {
   const getLocalPaintStyles = jest.fn(() => { return Array<IPaintStyle>() })
-  const figma = { getLocalPaintStyles: getLocalPaintStyles }
+  const figma = makePluginAPI({ getLocalPaintStyles: getLocalPaintStyles })
   inferColors(figma)
   expect(getLocalPaintStyles).toHaveBeenCalled()
 })
@@ -27,7 +28,7 @@ test("Image paints and video paints are ignored", () => {
 
   const paintStyle = makePaintStyle({paints: [imagePaint, videoPaint]})
   const getLocalPaintStyles = jest.fn(() => { return [paintStyle] })
-  const figma = { getLocalPaintStyles: getLocalPaintStyles }
+  const figma = makePluginAPI({ getLocalPaintStyles: getLocalPaintStyles })
   expect(inferColors(figma)).toEqual([])
 })
 

--- a/figma_plugin/test/color.test.ts
+++ b/figma_plugin/test/color.test.ts
@@ -88,7 +88,7 @@ public extension Color {
     /// SwiftUI's Color.
     ///
     /// Xcode's autocomplete allows for easy discovery of design system colors.
-    /// At any call site that requires a color, type \`Color.DesignSystem.<esc>\`
+    /// At any call site that requires a color, type \`Color.DesignSystem.<ctrl-space>\`
     struct DesignSystem {
         /// Docstring A
         public static let primaryColor = Color(red: 0.5, green: 0.5, blue: 0.5, opacity: 0.5)

--- a/figma_plugin/test/common.test.ts
+++ b/figma_plugin/test/common.test.ts
@@ -1,5 +1,6 @@
-import { sanitizeName } from '../src/core/utils/common.ts'
+import { escapeSwiftToken } from '../src/core/utils/common.ts'
 import { humanifyNumber } from '../src/core/utils/common.ts'
+import { sanitizeName } from '../src/core/utils/common.ts'
 
 test("Sanitize name", () => {
   expect(sanitizeName("test/color")).toBe("testColor")
@@ -9,6 +10,11 @@ test("Sanitize name", () => {
   expect(sanitizeName("12")).toBe("twelve")
   expect(sanitizeName("-1")).toBe("minusOne")
   expect(sanitizeName("-test")).toBe("minusTest")
+})
+
+test("Tokens that match a Swift reserved word are escaped", () => {
+  expect(escapeSwiftToken('catch')).toBe('`catch`')
+  expect(escapeSwiftToken('foobar')).toBe('foobar')
 })
 
 test("Humanify number", () => {

--- a/figma_plugin/test/common.test.ts
+++ b/figma_plugin/test/common.test.ts
@@ -1,0 +1,24 @@
+import { sanitizeName } from '../src/core/utils/common.ts'
+import { humanifyNumber } from '../src/core/utils/common.ts'
+
+test("Sanitize name", () => {
+  expect(sanitizeName("test/color")).toBe("testColor")
+  expect(sanitizeName("test:color")).toBe("testColor")
+  expect(sanitizeName("test+color")).toBe("testColor")
+  expect(sanitizeName("1")).toBe("one")
+  expect(sanitizeName("12")).toBe("twelve")
+  expect(sanitizeName("-1")).toBe("minusOne")
+  expect(sanitizeName("-test")).toBe("minusTest")
+})
+
+test("Humanify number", () => {
+  expect(humanifyNumber(0.0001)).toBe(0)
+  expect(humanifyNumber(0.9999)).toBe(1)
+  expect(humanifyNumber(1.0001)).toBe(1)
+  expect(humanifyNumber(1.9999)).toBe(2)
+  expect(humanifyNumber(-0.0001)).toBe(0)
+  expect(humanifyNumber(-0.9999)).toBe(-1)
+  expect(humanifyNumber(-0.24)).toBe(-0.24)
+  expect(humanifyNumber(0.24)).toBe(0.24)
+})
+

--- a/figma_plugin/test/effect.test.ts
+++ b/figma_plugin/test/effect.test.ts
@@ -37,7 +37,7 @@ test("Inferring effects from Figma uses the plugin API call getLocalEffectsStyle
 test("A layer blur figma effect is converted into a Blur model", () => {
   const figmaEffect = makeLayerBlurEffect({radius: 1})
   const blurModel = effectToDSEffect(figmaEffect)
-  expect(blurModel).toMatchObject({radius: 1})
+  expect(blurModel).toMatchObject({radius: 0.5}) // The radius is corrected by a factor of 1/2 for visual consistency between Figma and SwiftUI
 })
 
 test("A drop shadow figma effect is converted into a Shadow model", () => {
@@ -82,7 +82,7 @@ test("An effect style maps to a composite effect model", () => {
         radius: 0.5,
       },
       {
-        radius: 2
+        radius: 1
       }
     ]
   })

--- a/figma_plugin/test/effect.test.ts
+++ b/figma_plugin/test/effect.test.ts
@@ -1,0 +1,135 @@
+// API bridge types
+import { IEffect } from '../src/core/origins/figma/api_bridge.ts'
+import { IEffectStyle } from '../src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { Blur } from '../src/core/models/effect.ts'
+import { NamedCompositeEffect } from '../src/core/models/effect.ts'
+import { Shadow } from '../src/core/models/effect.ts'
+import { effectToDSEffect } from '../src/core/origins/figma/infer_effects.ts'
+import { emitEffect } from '../src/core/targets/swiftui/emit_effects.ts'
+import { inferEffects } from '../src/core/origins/figma/infer_effects.ts'
+import { logToUser } from '../src/core/utils/log.ts'
+
+// Specific to testing
+import { makeBackgroundBlurEffect } from './factories.ts'
+import { makeDropShadowEffect } from './factories.ts'
+import { makeEffectStyle } from './factories.ts'
+import { makeInnerShadowEffect } from './factories.ts'
+import { makeLayerBlurEffect } from './factories.ts'
+import { makePluginAPI } from './factories.ts'
+
+// Don't actually log to the user.
+// Instead, inspect a mock and ensure the right message is being sent.
+jest.mock('../src/core/utils/log.ts', () => {
+  return { logToUser: jest.fn() }
+})
+afterEach(() => { jest.restoreAllMocks() })
+
+test("Inferring effects from Figma uses the plugin API call getLocalEffectsStyles", () => {
+  const getLocalEffectStyles = jest.fn(() => { return Array<IEffectStyle>() })
+  const figma = makePluginAPI({ getLocalEffectStyles: getLocalEffectStyles })
+  inferEffects(figma)
+  expect(getLocalEffectStyles).toHaveBeenCalled()
+})
+
+test("If an effect style contains an inner shadow, we alert the user", () => {
+  const style = makeEffectStyle({effects: [makeInnerShadowEffect()]})
+  const figma = makePluginAPI({ getLocalEffectStyles: () => { return [style] } })
+  inferEffects(figma)
+  expect(logToUser).toBeCalledWith('DSCompiler does not yet understand effect type INNER_SHADOW')
+})
+
+test("If an effect style has a background blur, we alert the user", () => {
+  const style = makeEffectStyle({effects: [makeBackgroundBlurEffect()]})
+  const figma = makePluginAPI({ getLocalEffectStyles: () => { return [style] } })
+  inferEffects(figma)
+  expect(logToUser).toBeCalledWith('DSCompiler does not yet understand effect type BACKGROUND_BLUR')
+})
+
+test("A layer blur figma effect is converted into a Blur model", () => {
+  const figmaEffect = makeLayerBlurEffect({radius: 1})
+  const blurModel = effectToDSEffect(figmaEffect)
+  expect(blurModel).toMatchObject({radius: 1})
+})
+
+test("A drop shadow figma effect is converted into a Shadow model", () => {
+  const figmaEffect = makeDropShadowEffect({
+    color: {r: 1, g: 0, b: 0, a: 1},
+    offset: {x: 9, y: 9},
+    radius: 1,
+    spread: 5
+  })
+  const shadowModel = effectToDSEffect(figmaEffect)
+  expect(shadowModel).toMatchObject({
+    color: {red: 1, green: 0, blue: 0, opacity: 1},
+    radius: 1,
+    offset: {x: 9, y: 9},
+    spread: 5
+  })
+})
+
+test("A drop shadow without a spread defaults to a null spread", () => {
+  const figmaEffect = makeDropShadowEffect()
+  const shadowModel = effectToDSEffect(figmaEffect)
+  expect(shadowModel).toMatchObject({
+    spread: null
+  })
+})
+
+test("An effect style maps to a composite effect model", () => {
+  const effectStyle = makeEffectStyle({
+      name: "My Style",
+      description: "style description",
+      effects: [
+        makeDropShadowEffect({
+          color: {r: 1, g: 0, b: 0, a: 1},
+          offset: {x: 1, y: 1},
+          radius: 1,
+          spread: 1
+        }),
+        makeLayerBlurEffect({
+          radius: 2
+        })
+      ]
+  })
+  const figma = makePluginAPI({ getLocalEffectStyles: () => { return [effectStyle] } })
+  const compositeEffects = inferEffects(figma)
+  expect(compositeEffects.length).toBe(1)
+  expect(compositeEffects[0]).toMatchObject({
+    name: "myStyle",
+    description: "style description",
+    effects: [
+      {
+        color: {red: 1, green: 0, blue: 0, opacity: 1},
+        offset: {x: 1, y: 1},
+        radius: 1,
+        spread: 1
+      },
+      {
+        radius: 2
+      }
+    ]
+  })
+})
+
+test("A blur model has corresponding SwiftUI", () => {
+  const blur: Blur = {radius: 5}
+  const swiftUI = emitEffect(blur)
+  expect(swiftUI).toBe(".blur(radius: 5)\n")
+})
+
+test("A drop shadow model without spread has corresponding SwiftUI", () => {
+  const shadow: Shadow = {
+    color: { red: 1, green: 0, blue: 0, opacity: 1},
+    radius: 5,
+    offset: {x: 1, y: 1},
+    spread: null
+  }
+  const swiftUI = emitEffect(shadow)
+  expect(swiftUI).toBe(".shadow(color: Color(red:1, green: 0, blue: 0, opacity: 1), radius: 5, x: 1, y:1)\n")
+})
+
+// This will fail. There is no spread logic yet.
+// test("A drop shadow with spread has corresponding SwiftUI", () => {
+// }

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -1,13 +1,18 @@
 import { IColorStop } from '../src/core/origins/figma/api_bridge.ts'
+import { IDropShadowEffect } from '../src/core/origins/figma/api_bridge.ts'
+import { IEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IEffectStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
+import { IInnerShadowEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { IPluginAPI } from '../src/core/origins/figma/api_bridge.ts'
+import { IRGBA } from '../src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from '../src/core/origins/figma/api_bridge.ts'
+import { IBlurEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { ITransform } from '../src/core/origins/figma/api_bridge.ts'
 
-
+/* Plugin API Factory */
 interface _IPluginAPI {
   getLocalPaintStyles?: () => IPaintStyle[]
   getLocalEffectStyles?: () => IEffectStyle[]
@@ -21,17 +26,11 @@ export function makePluginAPI({ getLocalPaintStyles, getLocalEffectStyles }: _IP
   }
 }
 
+/* PaintStyle Factory */
 interface _IPaintStyle {
   name?: string
   description?: string
   paints?: ReadonlyArray<IPaint>
-}
-
-interface _IGradientPaint {
-  type?: 'GRADIENT_LINEAR' | 'GRADIENT_RADIAL' | 'GRADIENT_ANGULAR' | 'GRADIENT_DIAMOND'
-  gradientTransform?: ITransform
-  gradientStops?: ReadonlyArray<IColorStop>
-  opacity?: number
 }
 
 export function makePaintStyle({ name, description, paints }: _IPaintStyle = {})
@@ -43,8 +42,18 @@ export function makePaintStyle({ name, description, paints }: _IPaintStyle = {})
   }
 }
 
+/* SolidPaint Factory */
 function makePaint(): ISolidPaint {
   return {type: 'SOLID', color: {r: 1, g: 1, b: 1}, opacity: 0.5}
+}
+
+
+/* GradientPaint Factory */
+interface _IGradientPaint {
+  type?: 'GRADIENT_LINEAR' | 'GRADIENT_RADIAL' | 'GRADIENT_ANGULAR' | 'GRADIENT_DIAMOND'
+  gradientTransform?: ITransform
+  gradientStops?: ReadonlyArray<IColorStop>
+  opacity?: number
 }
 
 export function makeGradientPaint({ type, gradientTransform, gradientStops, opacity }: _IGradientPaint = {})
@@ -60,4 +69,55 @@ function makeGradientStops(): ReadonlyArray<IColorStop> {
   const colorA = {r: 1, g: 0, b: 0, a: 1}
   const colorB = {r: 1, g: 1, b: 1, a: 0}
   return [{color: colorA, position: 0}, {color: colorB, position: 1}]
+}
+
+
+/* EffectStyle Factory */
+
+interface _IEffectStyle {
+  name?: string
+  description?: string
+  effects?: ReadonlyArray<IEffect>
+}
+
+export function makeEffectStyle({ name, description, effects }: _IEffectStyle = {})
+: IEffectStyle {
+  return {
+    name: name || "default effect",
+    description: description || "default description",
+    effects: effects || [makeDropShadowEffect()]
+  }
+}
+
+
+/* Shadow Factories */
+interface _IDropShadowEffect {
+  readonly color?: IRGBA
+  readonly offset?: {x: number, y: number}
+  readonly radius?: number
+  readonly spread?: number
+}
+
+export function makeDropShadowEffect({ color, offset, radius, spread }: _IDropShadowEffect = {})
+: IDropShadowEffect {
+  return {
+    type: 'DROP_SHADOW',
+    color: color || {r: 0, g: 0, b: 0, a: 1},
+    offset: offset || {x: 3, y: 3},
+    radius: radius !== undefined ? radius : 5,
+    spread: spread
+  }
+}
+
+export function makeInnerShadowEffect(): IInnerShadowEffect {
+  return {type: 'INNER_SHADOW'}
+}
+
+/* Blur Factories */
+export function makeBackgroundBlurEffect(): IBlurEffect {
+  return {type: 'BACKGROUND_BLUR', radius: 10}
+}
+
+export function makeLayerBlurEffect({radius}: {radius?: number} = {}): IBlurEffect {
+  return {type: 'LAYER_BLUR', radius: radius !== undefined ? radius : 10 }
 }

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -1,10 +1,25 @@
 import { IColorStop } from '../src/core/origins/figma/api_bridge.ts'
+import { IEffectStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
+import { IPluginAPI } from '../src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { ITransform } from '../src/core/origins/figma/api_bridge.ts'
 
+
+interface _IPluginAPI {
+  getLocalPaintStyles?: () => IPaintStyle[]
+  getLocalEffectStyles?: () => IEffectStyle[]
+}
+
+export function makePluginAPI({ getLocalPaintStyles, getLocalEffectStyles }: _IPluginAPI = {})
+: IPluginAPI {
+  return {
+    getLocalPaintStyles: getLocalPaintStyles || jest.fn(() => { return Array<IPaintStyle>() }),
+    getLocalEffectStyles: getLocalEffectStyles || jest.fn(() => { return Array<IEffectStyle>() }),
+  }
+}
 
 interface _IPaintStyle {
   name?: string

--- a/figma_plugin/test/gradient.test.ts
+++ b/figma_plugin/test/gradient.test.ts
@@ -14,8 +14,9 @@ import { transformToModelCoordinates } from '../src/core/origins/figma/infer_gra
 import { logToUser } from '../src/core/utils/log.ts'
 
 // Specific to testing
-import { makePaintStyle } from './factories.ts'
 import { makeGradientPaint } from './factories.ts'
+import { makePaintStyle } from './factories.ts'
+import { makePluginAPI } from './factories.ts'
 
 // Don't actually log to the user.
 // Instead, inspect a mock and ensure the right message is being sent.
@@ -26,7 +27,7 @@ afterEach(() => { jest.restoreAllMocks() })
 
 test("Infering gradients from Figma uses the plugin API call getLocalPaintStyles", () => {
   const getLocalPaintStyles = jest.fn(() => { return Array<IPaintStyle>() })
-  const figma = { getLocalPaintStyles: getLocalPaintStyles }
+  const figma = makePluginAPI({ getLocalPaintStyles: getLocalPaintStyles })
   inferGradients(figma)
   expect(getLocalPaintStyles).toHaveBeenCalled()
 })

--- a/figma_plugin/test/gradient.test.ts
+++ b/figma_plugin/test/gradient.test.ts
@@ -157,7 +157,7 @@ public extension LinearGradient {
     /// SwiftUI's LinearGradient.
     ///
     /// Xcode's autocomplete allows for easy discovery of design system linear gradients.
-    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<esc>\`
+    /// At any call site that requires a linear gradient, type \`LinearGradient.DesignSystem.<ctrl-space>\`
     struct DesignSystem {
         /// My first docstring
         public static let gradientA = LinearGradient(


### PR DESCRIPTION
- Effects defined as "Local Styles" in Figma are code generated as ViewModifiers in SwiftUI
  - Modify local styles in Figma's inspect panel:
<img width="400" alt="Screenshot 2023-07-06 at 10 51 13" src="https://github.com/lzell/dscompiler/assets/35940/6e41f122-e931-4a87-bf1f-a76d28524a3e">

- An effect defined in Figma as "Primary shadow" corresponds to a usage call in SwiftUI of: 
```
var body: some View {
   Rectangle()
      .fill(.red)
      .primaryShadow()
}
```

