### PR TITLE
Add mapping from Figma text style to SwiftUI font

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -91,6 +91,16 @@ Run linter and apply fixes:
     npm run linter_fixer
 
 
+### Using system fonts
+
+- If your Figma designs use [SF or New York fonts](https://developer.apple.com/fonts/), dscompiler will map them to system fonts automatically.
+- Use the MacOS program 'Font Book' to browse fonts
+- If the font has a gear icon next to it [here](https://developer.apple.com/fonts/system-fonts/), then it is built in. If a font has a download icon, then you need to add it to your Xcode project.
+  - How to add a custom font to Xcode: [link](https://www.threads.net/t/Cujx_LEOS4e)
+- It would be great if we could automate this all away. Let the designer pick the font they want, and we modify the Xcode project if needed.
+
+
+
 ## References for project setup files
 
 - `manifest.json`
@@ -104,3 +114,4 @@ Run linter and apply fixes:
 
 - `jest.config.js`
 [Jest configuration for unit tests](https://jestjs.io/docs/configuration)
+

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -91,15 +91,14 @@ Run linter and apply fixes:
     npm run linter_fixer
 
 
-### Using system fonts
+### Mapping Figma text styles to SwiftUI fonts
 
 - If your Figma designs use [SF or New York fonts](https://developer.apple.com/fonts/), dscompiler will map them to system fonts automatically.
-- Use the MacOS program 'Font Book' to browse fonts
-- If the font has a gear icon next to it [here](https://developer.apple.com/fonts/system-fonts/), then it is built in. If a font has a download icon, then you need to add it to your Xcode project.
-  - How to add a custom font to Xcode: [link](https://www.threads.net/t/Cujx_LEOS4e)
+- For all other fonts, check to see if your desired font has a gear icon next to it in [Apple's system font list](https://developer.apple.com/fonts/system-fonts/)
+  - If the gear icon is present, then dscompiler will map your Figma text styles to custom font without any work on your end.
+  - If the gear icon is missing, then you must add your custom font to Xcode for dscompiler's mapping to work as expected.
+    - How to add a custom font to Xcode: [link](https://www.louzell.com/notes/swiftui_custom_font.html)
 - It would be great if we could automate this all away. Let the designer pick the font they want, and we modify the Xcode project if needed.
-
-
 
 ## References for project setup files
 
@@ -114,4 +113,3 @@ Run linter and apply fixes:
 
 - `jest.config.js`
 [Jest configuration for unit tests](https://jestjs.io/docs/configuration)
-

--- a/figma_plugin/src/core/models/font.ts
+++ b/figma_plugin/src/core/models/font.ts
@@ -1,0 +1,13 @@
+export interface Font {
+  readonly atomName: string | null
+  readonly size: number
+}
+
+export interface SystemFont extends Font {
+  readonly weight: string
+  readonly design: string
+}
+
+export interface CustomFont extends Font {
+  readonly fontName: string
+}

--- a/figma_plugin/src/core/models/font.ts
+++ b/figma_plugin/src/core/models/font.ts
@@ -1,5 +1,6 @@
 export interface Font {
-  readonly atomName: string | null
+  readonly atomName: string
+  readonly description: string
   readonly size: number
 }
 

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -97,6 +97,7 @@ export interface IBlurEffect {
 
 export interface ITextStyle {
   name: string
+  description: string
   fontSize: number
   fontName: IFontName
 }

--- a/figma_plugin/src/core/origins/figma/api_bridge.ts
+++ b/figma_plugin/src/core/origins/figma/api_bridge.ts
@@ -21,6 +21,7 @@
 export interface IPluginAPI {
   getLocalPaintStyles(): IPaintStyle[]
   getLocalEffectStyles(): IEffectStyle[]
+  getLocalTextStyles(): ITextStyle[]
 }
 
 export interface IPaintStyle {
@@ -92,4 +93,15 @@ export interface IInnerShadowEffect {
 export interface IBlurEffect {
   readonly type: 'LAYER_BLUR' | 'BACKGROUND_BLUR'
   readonly radius: number
+}
+
+export interface ITextStyle {
+  name: string
+  fontSize: number
+  fontName: IFontName
+}
+
+export interface IFontName {
+  readonly family: string
+  readonly style: string
 }

--- a/figma_plugin/src/core/origins/figma/infer_fonts.ts
+++ b/figma_plugin/src/core/origins/figma/infer_fonts.ts
@@ -1,0 +1,63 @@
+import { camelCase } from 'lodash'
+import { replace } from 'lodash'
+
+// API bridge types
+import { IFontName } from 'src/core/origins/figma/api_bridge.ts'
+import { IPluginAPI } from 'src/core/origins/figma/api_bridge.ts'
+import { ITextStyle } from 'src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { Font, SystemFont, CustomFont } from 'src/core/models/font.ts'
+import { sanitizeName } from 'src/core/utils/common.ts'
+
+export function inferFonts(figma: IPluginAPI): ReadonlyArray<Font> {
+  return figma.getLocalTextStyles().sort((x,y) => y.fontSize - x.fontSize)
+                                   .map(textStyleToFont)
+}
+
+export function textStyleToFont(textStyle: ITextStyle): CustomFont | SystemFont {
+  const atomName = sanitizeName(textStyle.name)
+  const isSystem = /^(sf|new york)/i
+  let font: Font = { atomName: atomName, size: textStyle.fontSize }
+  if (isSystem.test(textStyle.fontName.family)) {
+    return {
+      ...font,
+      weight: systemFontWeight(textStyle),
+      design: systemFontDesign(textStyle)
+    }
+  }
+  return {
+    ...font,
+    fontName: postScriptFontName(textStyle.fontName)
+  }
+}
+
+function systemFontWeight(textStyle: ITextStyle): string {
+  return '.' + camelCase(stripWhitespace(textStyle.fontName.style))
+}
+
+function systemFontDesign(textStyle: ITextStyle): string {
+    const isRounded = /rounded/i
+    const isMono = /mono/i
+    const isSerif = /new york/i
+    if (isRounded.test(textStyle.fontName.family)) {
+      return '.rounded'
+    } else if (isMono.test(textStyle.fontName.family)) {
+      return '.monospaced'
+    } else if (isSerif.test(textStyle.fontName.family)) {
+      return '.serif'
+    } else {
+      return '.default'
+    }
+}
+
+function stripWhitespace(str: string): string {
+  return replace(str, /\s/g, '')
+}
+
+// Use the Mac application FontBook to view the PostScript name of
+// any font (tap the 'i' icon after selecting the font)
+function postScriptFontName(fontName: IFontName): string {
+  return  stripWhitespace(fontName.family) + '-' + stripWhitespace(fontName.style)
+}
+

--- a/figma_plugin/src/core/origins/figma/infer_fonts.ts
+++ b/figma_plugin/src/core/origins/figma/infer_fonts.ts
@@ -18,7 +18,7 @@ export function inferFonts(figma: IPluginAPI): ReadonlyArray<Font> {
 export function textStyleToFont(textStyle: ITextStyle): CustomFont | SystemFont {
   const atomName = sanitizeName(textStyle.name)
   const isSystem = /^(sf|new york)/i
-  let font: Font = { atomName: atomName, size: textStyle.fontSize }
+  const font: Font = { atomName: atomName, description: textStyle.description, size: textStyle.fontSize }
   if (isSystem.test(textStyle.fontName.family)) {
     return {
       ...font,
@@ -60,4 +60,3 @@ function stripWhitespace(str: string): string {
 function postScriptFontName(fontName: IFontName): string {
   return  stripWhitespace(fontName.family) + '-' + stripWhitespace(fontName.style)
 }
-

--- a/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
@@ -1,0 +1,54 @@
+import { CustomFont } from 'src/core/models/font.ts'
+import { Font } from 'src/core/models/font.ts'
+import { SystemFont } from 'src/core/models/font.ts'
+import { escapeSwiftToken } from 'src/core/utils/common.ts'
+
+// Given a font model, return an equivalent SwiftUI font definition.
+export function emitFont(font: Font, indentLevel=0): string {
+  const prefix = ' '.repeat(indentLevel)
+  return `${prefix}/// ${font.description}\n` +
+         `${prefix}public static let ${escapeSwiftToken(font.atomName)} = ${getFontCall(font)}\n`
+}
+
+// Given a list of fonts, return an equivalent SwiftUI file defining all fonts.
+export function emitFonts(fonts: Font[]): string {
+  let swift_content = `import SwiftUI
+
+public extension Font {
+    /// Namespace to prevent naming collisions with static accessors on
+    /// SwiftUI's Font.
+    ///
+    /// Xcode's autocomplete allows for easy discovery of design system fonts.
+    /// At any call site that requires a font, type \`Font.DesignSystem.<ctrl-space>\`
+    struct DesignSystem {
+`
+  const indentLevel = 8
+  for (let font of fonts) {
+    swift_content += `${emitFont(font, indentLevel)}\n`
+  }
+  swift_content = swift_content.slice(0, -1)
+
+  swift_content += "    }\n}\n"
+  return swift_content
+}
+
+function getFontCall(font: Font): string {
+  if (isCustom(font)) {
+    return `Font.custom("${font.fontName}", size: ${font.size})`
+  } else if (isSystem(font)) {
+    return `Font.system(size: ${font.size}, weight: ${font.weight}, design: ${font.design})`
+  } else {
+    const msg = "Unexpected error, please file a github issue and assign it to lzell"
+    console.assert(false, msg)
+    return msg
+  }
+}
+
+function isCustom(font: Font): font is CustomFont {
+  return (font as CustomFont).fontName !== undefined
+}
+
+function isSystem(font: Font): font is SystemFont {
+  return (font as SystemFont).design !== undefined
+}
+

--- a/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
@@ -23,7 +23,7 @@ public extension Font {
     struct DesignSystem {
 `
   const indentLevel = 8
-  for (let font of fonts) {
+  for (const font of fonts) {
     swift_content += `${emitFont(font, indentLevel)}\n`
   }
   swift_content = swift_content.slice(0, -1)

--- a/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
+++ b/figma_plugin/src/core/targets/swiftui/emit_fonts.ts
@@ -11,7 +11,7 @@ export function emitFont(font: Font, indentLevel=0): string {
 }
 
 // Given a list of fonts, return an equivalent SwiftUI file defining all fonts.
-export function emitFonts(fonts: Font[]): string {
+export function emitFonts(fonts: ReadonlyArray<Font>): string {
   let swift_content = `import SwiftUI
 
 public extension Font {

--- a/figma_plugin/src/main.ts
+++ b/figma_plugin/src/main.ts
@@ -1,8 +1,10 @@
 import { emitColors } from 'src/core/targets/swiftui/emit_colors.ts'
 import { emitCompositeEffects } from 'src/core/targets/swiftui/emit_effects.ts'
+import { emitFonts } from 'src/core/targets/swiftui/emit_fonts.ts'
 import { emitGradients } from 'src/core/targets/swiftui/emit_gradients.ts'
 import { inferColors } from 'src/core/origins/figma/infer_colors.ts'
 import { inferEffects } from 'src/core/origins/figma/infer_effects.ts'
+import { inferFonts } from 'src/core/origins/figma/infer_fonts.ts'
 import { inferGradients } from 'src/core/origins/figma/infer_gradients.ts'
 
 figma.showUI(__html__)
@@ -46,10 +48,24 @@ function returnSwiftUIEffects() {
   )
 }
 
+// Returns SwiftUI fonts to the caller (the browser environment)
+function returnSwiftUIFonts() {
+  figma.ui.postMessage(
+    {
+      'message': 'return-export-fonts-button-action',
+      'argument': {
+        'file_name': 'Font.swift',
+        'file_body': emitFonts(inferFonts(figma)),
+      }
+    }
+  )
+}
+
 const messageCallDictionary: Record<string, () => void> = {
   'close-button-action': figma.closePlugin,
   'export-colors-button-action': returnSwiftUIColors,
   'export-effects-button-action': returnSwiftUIEffects,
+  'export-fonts-button-action': returnSwiftUIFonts,
   'export-gradients-button-action': returnSwiftUIGradients,
 }
 

--- a/figma_plugin/src/ui.html.liquid
+++ b/figma_plugin/src/ui.html.liquid
@@ -11,6 +11,10 @@
 </div>
 <br>
 <div>
+  <button id='export-fonts-button'>Emit SwiftUI Fonts</button>
+</div>
+<br>
+<div>
   <button id='close-button'>Close</button>
 </div>
 

--- a/figma_plugin/src/ui.ts
+++ b/figma_plugin/src/ui.ts
@@ -11,8 +11,9 @@ window.onmessage = async (event) => {
   console.assert(pluginMessage, "Expecting a plugin message")
   switch (pluginMessage['message']) {
     case 'return-export-colors-button-action':
-    case 'return-export-gradients-button-action':
     case 'return-export-effects-button-action':
+    case 'return-export-fonts-button-action':
+    case 'return-export-gradients-button-action':
       exportButtonActionDidReturn(pluginMessage['argument'])
       break
     default:
@@ -56,6 +57,7 @@ function attachButtonActions(buttonsAndActions: [string, string][]) {
 attachButtonActions([
   ['close-button', 'close-button-action'],
   ['export-colors-button', 'export-colors-button-action'],
-  ['export-gradients-button', 'export-gradients-button-action'],
   ['export-effects-button', 'export-effects-button-action'],
+  ['export-fonts-button', 'export-fonts-button-action'],
+  ['export-gradients-button', 'export-gradients-button-action'],
 ])

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -3,6 +3,7 @@ import { IColorStop } from '../src/core/origins/figma/api_bridge.ts'
 import { IDropShadowEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IEffectStyle } from '../src/core/origins/figma/api_bridge.ts'
+import { IFontName } from '../src/core/origins/figma/api_bridge.ts'
 import { IGradientPaint } from '../src/core/origins/figma/api_bridge.ts'
 import { IInnerShadowEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IPaint } from '../src/core/origins/figma/api_bridge.ts'
@@ -126,4 +127,22 @@ export function makeBackgroundBlurEffect(): IBlurEffect {
 
 export function makeLayerBlurEffect({radius}: {radius?: number} = {}): IBlurEffect {
   return {type: 'LAYER_BLUR', radius: radius !== undefined ? radius : 10 }
+}
+
+/* Font Factories */
+interface _ITextStyle {
+  name?: string
+  description?: string
+  fontName?: IFontName,
+  fontSize?: number
+}
+
+export function makeTextStyle({ name, description, fontName, fontSize }: _ITextStyle = {})
+: ITextStyle {
+  return {
+    name: name || "default text",
+    description: description || "default description",
+    fontName: fontName !== undefined ? fontName : {family: 'SF Pro', style: 'Regular'},
+    fontSize: fontSize || 12
+  }
 }

--- a/figma_plugin/test/factories.ts
+++ b/figma_plugin/test/factories.ts
@@ -1,3 +1,4 @@
+import { IBlurEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IColorStop } from '../src/core/origins/figma/api_bridge.ts'
 import { IDropShadowEffect } from '../src/core/origins/figma/api_bridge.ts'
 import { IEffect } from '../src/core/origins/figma/api_bridge.ts'
@@ -9,20 +10,25 @@ import { IPaintStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { IPluginAPI } from '../src/core/origins/figma/api_bridge.ts'
 import { IRGBA } from '../src/core/origins/figma/api_bridge.ts'
 import { ISolidPaint } from '../src/core/origins/figma/api_bridge.ts'
-import { IBlurEffect } from '../src/core/origins/figma/api_bridge.ts'
+import { ITextStyle } from '../src/core/origins/figma/api_bridge.ts'
 import { ITransform } from '../src/core/origins/figma/api_bridge.ts'
 
 /* Plugin API Factory */
 interface _IPluginAPI {
   getLocalPaintStyles?: () => IPaintStyle[]
   getLocalEffectStyles?: () => IEffectStyle[]
+  getLocalTextStyles?: () => ITextStyle[]
 }
 
-export function makePluginAPI({ getLocalPaintStyles, getLocalEffectStyles }: _IPluginAPI = {})
+export function makePluginAPI(
+  { getLocalPaintStyles,
+    getLocalEffectStyles,
+    getLocalTextStyles }: _IPluginAPI = {})
 : IPluginAPI {
   return {
     getLocalPaintStyles: getLocalPaintStyles || jest.fn(() => { return Array<IPaintStyle>() }),
     getLocalEffectStyles: getLocalEffectStyles || jest.fn(() => { return Array<IEffectStyle>() }),
+    getLocalTextStyles: getLocalTextStyles || jest.fn(() => { return Array<ITextStyle>() }),
   }
 }
 

--- a/figma_plugin/test/font.test.ts
+++ b/figma_plugin/test/font.test.ts
@@ -2,10 +2,16 @@
 import { ITextStyle } from '../src/core/origins/figma/api_bridge.ts'
 
 // DSCompiler
+import { CustomFont } from '../src/core/models/font.ts'
+import { SystemFont } from '../src/core/models/font.ts'
+import { emitFont } from '../src/core/targets/swiftui/emit_fonts.ts'
+import { emitFonts } from '../src/core/targets/swiftui/emit_fonts.ts'
 import { inferFonts } from '../src/core/origins/figma/infer_fonts.ts'
+import { textStyleToFont } from '../src/core/origins/figma/infer_fonts.ts'
 
 // Specific to testing
 import { makePluginAPI } from './factories.ts'
+import { makeTextStyle } from './factories.ts'
 
 test("Infering fonts from Figma uses the plugin API call getLocalTextStyles", () => {
   const getLocalTextStyles = jest.fn(() => { return Array<ITextStyle>() })
@@ -13,3 +19,143 @@ test("Infering fonts from Figma uses the plugin API call getLocalTextStyles", ()
   inferFonts(figma)
   expect(getLocalTextStyles).toHaveBeenCalled()
 })
+
+test("A text style that uses a New York font converts to a SystemFont with serif design", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'New York', style: 'Regular'}})
+  const font = textStyleToFont(textStyle) as SystemFont
+  expect(font.design).toBe(".serif")
+  expect(font.weight).toBe(".regular")
+})
+
+test("A text style that uses an SF rounded font converts to a SystemFont with rounded design", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'SF Pro Rounded', style: 'Regular'}})
+  const font = textStyleToFont(textStyle) as SystemFont
+  expect(font.design).toBe(".rounded")
+})
+
+test("A text style that uses an SF monospace font converts to a SystemFont with monospaced design", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'SF Mono', style: 'Regular'}})
+  const font = textStyleToFont(textStyle) as SystemFont
+  expect(font.design).toBe(".monospaced")
+})
+
+test("A text style that uses a SF Pro converts to a SystemFont with default design", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'SF Pro', style: 'Regular'}})
+  const font = textStyleToFont(textStyle) as SystemFont
+  expect(font.design).toBe(".default")
+})
+
+test("A text style's font style is camelcased on conversion to a Font model", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'SF Pro', style: 'Condensed Bold'}})
+  const font = textStyleToFont(textStyle) as SystemFont
+  expect(font.weight).toBe(".condensedBold")
+})
+
+test("The family and text style of non-system fonts are concatenated to form the custom font name", () => {
+  const textStyle = makeTextStyle({fontName: {family: 'American Typewriter', style: 'Condensed Bold'}})
+  const font = textStyleToFont(textStyle) as CustomFont
+  expect(font.fontName).toBe("AmericanTypewriter-CondensedBold")
+})
+
+test("Named system fonts are inferred from text styles", () => {
+  const textStyle = {
+    name: 'my font',
+    description: 'my description',
+    fontName: {family: 'SF Pro', style: 'Regular'},
+    fontSize: 12
+  }
+  const getLocalTextStyles = () => [textStyle]
+  const figma = makePluginAPI({ getLocalTextStyles: getLocalTextStyles })
+  const fonts = inferFonts(figma)
+  expect(fonts.length).toBe(1)
+  expect(fonts[0]).toMatchObject({
+    atomName: 'myFont',
+    description: 'my description',
+    size: 12,
+    design: '.default',
+    weight: '.regular',
+  })
+})
+
+test("Named custom fonts are inferred from text styles", () => {
+  const textStyle = {
+    name: 'my font',
+    description: 'my description',
+    fontName: {family: 'American Typewriter', style: 'Condensed Bold'},
+    fontSize: 12
+  }
+  const getLocalTextStyles = () => [textStyle]
+  const figma = makePluginAPI({ getLocalTextStyles: getLocalTextStyles })
+  const fonts = inferFonts(figma)
+  expect(fonts.length).toBe(1)
+  expect(fonts[0]).toMatchObject({
+    atomName: 'myFont',
+    description: 'my description',
+    size: 12,
+    fontName: 'AmericanTypewriter-CondensedBold',
+  })
+})
+
+test("A system font model has a SwiftUI equivalent", () => {
+  const systemFont: SystemFont = {
+    atomName: 'myFont',
+    description: 'my font',
+    size: 12,
+    weight: '.regular',
+    design: '.rounded'
+  }
+  const swiftUI = emitFont(systemFont)
+  expect(swiftUI).toBe(
+    '/// my font\n' +
+    'public static let myFont = Font.system(size: 12, weight: .regular, design: .rounded)\n'
+  )
+})
+
+test("A custom font model has a SwiftUI equivalent", () => {
+  const customFont: CustomFont = {
+    atomName: 'myFont',
+    description: 'my font',
+    size: 12,
+    fontName: 'AmericanTypewriter-CondensedBold',
+  }
+  const swiftUI = emitFont(customFont)
+  expect(swiftUI).toBe(
+    '/// my font\n' +
+    'public static let myFont = Font.custom("AmericanTypewriter-CondensedBold", size: 12)\n'
+  )
+})
+
+test("A list of fonts has a SwiftUI equivalent file", () => {
+  const systemFont: SystemFont = {
+    atomName: 'firstFont',
+    description: 'my first font',
+    size: 12,
+    weight: '.regular',
+    design: '.rounded'
+  }
+  const customFont: CustomFont = {
+    atomName: 'secondFont',
+    description: 'my second font',
+    size: 12,
+    fontName: 'AmericanTypewriter-CondensedBold',
+  }
+  const swiftUI = emitFonts([systemFont, customFont])
+  expect(swiftUI).toBe(`import SwiftUI
+
+public extension Font {
+    /// Namespace to prevent naming collisions with static accessors on
+    /// SwiftUI's Font.
+    ///
+    /// Xcode's autocomplete allows for easy discovery of design system fonts.
+    /// At any call site that requires a font, type \`Font.DesignSystem.<ctrl-space>\`
+    struct DesignSystem {
+        /// my first font
+        public static let firstFont = Font.system(size: 12, weight: .regular, design: .rounded)
+
+        /// my second font
+        public static let secondFont = Font.custom("AmericanTypewriter-CondensedBold", size: 12)
+    }
+}
+`)
+})
+

--- a/figma_plugin/test/font.test.ts
+++ b/figma_plugin/test/font.test.ts
@@ -1,0 +1,15 @@
+// API bridge types
+import { ITextStyle } from '../src/core/origins/figma/api_bridge.ts'
+
+// DSCompiler
+import { inferFonts } from '../src/core/origins/figma/infer_fonts.ts'
+
+// Specific to testing
+import { makePluginAPI } from './factories.ts'
+
+test("Infering fonts from Figma uses the plugin API call getLocalTextStyles", () => {
+  const getLocalTextStyles = jest.fn(() => { return Array<ITextStyle>() })
+  const figma = makePluginAPI({ getLocalTextStyles: getLocalTextStyles })
+  inferFonts(figma)
+  expect(getLocalTextStyles).toHaveBeenCalled()
+})


### PR DESCRIPTION
- Fonts saved in Figma as 'local styles' are mapped to SwiftUI fonts. Find your design's local styles in the inspect panel of Figma:
<img width="700" alt="figma_local_text_styles" src="https://github.com/lzell/dscompiler/assets/35940/7f961432-78bf-4874-a2f3-3427432afc53">

- Text styles that use 'New York' or 'SF' fonts are mapped automatically to SwiftUI system fonts. See the font unit tests at unit tests in `font.test.ts` for a spec on how this works.
- All other text styles are mapped to SwiftUI custom fonts.
- The emitted SwiftUI file puts a public extension on `Font` to add the `DesignSystem` namespace under it. This prevents style names defined in Figma from colliding with Apple's built in font names. For example, if your text style is named `headline` it will be available as `Font.DesignSystem.headline` to prevent collision with the built-in Apple font`Font.headline`.
